### PR TITLE
Fix README links and anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LabVIEW Icon Editor
 
-[![Build VI Package](https://github.com/ni/labview-icon-editor/actions/workflows/ci.yml/badge.svg)](https://github.com/ni/labview-icon-editor/actions/workflows/build-vi-package.yml)
+[![CI](https://github.com/ni/labview-icon-editor/actions/workflows/ci.yml/badge.svg)](https://github.com/ni/labview-icon-editor/actions/workflows/ci.yml)
 [![Latest Release](https://img.shields.io/github/v/release/ni/labview-icon-editor?label=release)](https://github.com/ni/labview-icon-editor/releases/latest)
 [![Discord](https://img.shields.io/discord/1319915996789739540?label=chat&logo=discord&style=flat)](https://discord.gg/q4d3ggrFVA)
 ![Coding hours](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ni/labview-icon-editor/metrics/badge.json)
@@ -8,16 +8,16 @@
 ---
 
 ## 🧭 Table of Contents (Users)
-- 📌 [Overview](#overview)  
-- 📦 [How to Install](#how-to-install)
+- 📌 [Overview](#-overview)
+- 📦 [How to Install](#-how-to-install)
 
-## 🧑‍💻 Table of Contents (Collaborators)  
-- 🧩 [Key Components](#key-components)  
-- 🚀 [Getting Started and Contributing](#getting-started-and-contributing)  
-- 🌱 [Feature and Experiment Workflows](#feature-and-experiment-workflows)  
-- 📚 [Documentation](#documentation)  
-- 📄 [License and CLA](#license-and-cla)  
-- 💬 [Contact and Discord](#contact-and-discord)
+## 🧑‍💻 Table of Contents (Collaborators)
+- 🧩 [Key Components](#-key-components)
+- 🚀 [Getting Started and Contributing](#-getting-started-and-contributing)
+- 🌱 [Feature and Experiment Workflows](#-feature-and-experiment-workflows)
+- 📚 [Documentation](#-documentation)
+- 📄 [License and CLA](#-license-and-cla)
+- 💬 [Contact and Discord](#-contact-and-discord)
 
 ---
 
@@ -27,9 +27,9 @@ The **LabVIEW Icon Editor** is an open-source, MIT-licensed project that release
 
 This means that your contributions—whether features, fixes, or docs—can ship with **official LabVIEW distributions**.
 
-- 🛠 Built entirely in G  
-- ⚙️ GitHub Actions orchestrate PowerShell-based CI workflows for testing, packaging, and publishing `.vip` artifacts  
-- 🔁 This project pioneered CI/CD pipelines, documentation, and foundational infrastructure that will eventually migrate to a centralized dependency repository so that it can expand along with other concepts (e.g. lvenv)  
+- 🛠 Built entirely in G.
+- ⚙️ GitHub Actions orchestrate PowerShell-based CI workflows for testing, packaging, and publishing `.vip` artifacts.
+- 🔁 This project pioneered CI/CD pipelines, documentation, and foundational infrastructure that will eventually migrate to a centralized dependency repository so that it can expand along with other concepts (e.g. lvenv).
 
 NI’s Open Source Program encourages **community collaboration** to evolve and improve this tooling that streamlines the way the LabVIEW community tests NI-governed features.
 
@@ -52,14 +52,14 @@ NI’s Open Source Program encourages **community collaboration** to evolve and 
 1. **Source Files**  
    - VI-based.
 
-2. **PowerShell Automation**  
-   - Built on [G-CLI](https://github.com/G-CLI/G-CLI)  
-   - Supports repeatable builds, releases, and CI tasks  
-   - Easy to use in local or GitHub-hosted runners
+2. **PowerShell Automation**
+   - Built on [G-CLI](https://github.com/G-CLI/G-CLI).
+   - Supports repeatable builds, releases, and CI tasks.
+   - Easy to use in local or GitHub-hosted runners.
 
-3. **CI/CD Workflows**  
-   - Build VI Package  
-   - Development Mode Toggle  
+3. **CI/CD Workflows**
+   - [Build VI Package](docs/ci/actions/build-vi-package.md)
+   - [Development Mode Toggle](docs/ci/actions/development-mode-toggle.md)
    - Run Unit Tests
 
 ---
@@ -71,7 +71,7 @@ We welcome both **code** and **non-code** contributions—from bug fixes and per
 - 📑 **CLA Required** – External contributors must sign a Contributor License Agreement before we can merge your pull request.  
 - 🧭 **Steering Committee** – A mix of members of LabVIEW R&D and community volunteers who guide the roadmap and have merge authority.  
 - 🔄 **Issues & Experiments** – Look for issues labeled “[Workflow: Open to contribution](https://github.com/ni/labview-icon-editor/labels/Workflow%3A%20Open%20to%20contribution)”.  
-- 🧪 **Long-Lived Features** – For experimental branches, see [EXPERIMENTS.md](docs/ci/experiments.md)
+- 🧪 **Long-Lived Features** – For experimental branches, see [EXPERIMENTS.md](docs/ci/experiments.md).
 
 More contribution info is in [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -120,23 +120,23 @@ More info in [EXPERIMENTS.md](docs/ci/experiments.md)
 
 Explore the `/docs` folder for technical references:
 
-- 📦 [Build VI Package](docs/ci/actions/build-vi-package.md)  
-- 🧪 [Development Mode Toggle](docs/ci/actions/development-mode-toggle.md)  
-- 🚢 [Multichannel Release Workflow](docs/ci/actions/multichannel-release-workflow.md)  
-- 🖥 [Runner Setup Guide](docs/ci/actions/runner-setup-guide.md)  
-- 🧬 [Injecting Repo/Org Metadata](docs/actions/injecting-repo-org-to-vi-package.md)  
-- 🧯 [Troubleshooting & FAQ](docs/ci/troubleshooting-faq.md)  
-- 🔬 [Experiments](docs/ci/experiments.md)  
-- 🛡️ [Maintainers Guide](docs/ci/actions/maintainers-guide.md)  
-- 🧱 [Troubleshooting Experiments](docs/ci/actions/troubleshooting-experiments.md)  
+- 📦 [Build VI Package](docs/ci/actions/build-vi-package.md)
+- 🧪 [Development Mode Toggle](docs/ci/actions/development-mode-toggle.md)
+- 🚢 [Multichannel Release Workflow](docs/ci/actions/multichannel-release-workflow.md)
+- 🖥 [Runner Setup Guide](docs/ci/actions/runner-setup-guide.md)
+- 🧬 [Injecting Repo/Org Metadata](docs/actions/injecting-repo-org-to-vi-package.md)
+- 🧯 [Troubleshooting & FAQ](docs/ci/troubleshooting-faq.md)
+- 🔬 [Experiments](docs/ci/experiments.md)
+- 🛡️ [Maintainers Guide](docs/ci/actions/maintainers-guide.md)
+- 🧱 [Troubleshooting Experiments](docs/ci/actions/troubleshooting-experiments.md)
 - 🏛️ [Governance](GOVERNANCE.md)
 
 ---
 
 ## 📄 License and CLA
 
-- **MIT License** – [LICENSE](LICENSE)  
-- **Contributor License Agreement** – Required before we can merge your contributions  
+- **MIT License** – [LICENSE](LICENSE).
+- **Contributor License Agreement** – Required before we can merge your contributions.
 
 By contributing, you grant NI the right to distribute your changes with LabVIEW.
 
@@ -144,8 +144,8 @@ By contributing, you grant NI the right to distribute your changes with LabVIEW.
 
 ## 💬 Contact and Discord
 
-- 🗨 [Discord Server](https://discord.gg/q4d3ggrFVA) – ask questions, propose ideas, get feedback  
-- 📂 [GitHub Discussions](https://github.com/ni/labview-icon-editor/discussions) – for formal proposals or workflows  
+- 🗨 [Discord Server](https://discord.gg/q4d3ggrFVA) – ask questions, propose ideas, get feedback.
+- 📂 [GitHub Discussions](https://github.com/ni/labview-icon-editor/discussions) – for formal proposals or workflows.
 
 ---
 


### PR DESCRIPTION
## Summary
- update CI badge link to current workflow
- fix table-of-contents anchors so intra-page navigation works
- link key components to docs and standardize punctuation

## Testing
- `npx markdownlint README.md` *(fails: npm error could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6890f1fcc7588329977d47c2fa110962