### PR TITLE
docs: add help comments to pipeline scripts

### DIFF
--- a/pipeline/scripts/AddTokenToLabVIEW.ps1
+++ b/pipeline/scripts/AddTokenToLabVIEW.ps1
@@ -1,4 +1,24 @@
-# Example: .\AddTokenToLabVIEW.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor"
+<#
+.SYNOPSIS
+    Adds a custom library path token to the LabVIEW INI file.
+
+.DESCRIPTION
+    Uses g-cli to call Create_LV_INI_Token.vi, inserting the provided path into
+    the LabVIEW INI file under the Localhost.LibraryPaths token. This enables
+    LabVIEW to locate local project libraries during development or builds.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used by g-cli (e.g., "2021").
+
+.PARAMETER SupportedBitness
+    Target bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root that should be added to the INI token.
+
+.EXAMPLE
+    .\AddTokenToLabVIEW.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor"
+#>
 
 param(
     [string]$MinimumSupportedLVVersion,

--- a/pipeline/scripts/Build_lvlibp.ps1
+++ b/pipeline/scripts/Build_lvlibp.ps1
@@ -1,4 +1,38 @@
-#Example: .\Build_lvlibp.ps1 - -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -Major 1 -Minor 0 -Patch 0 -Build 0 -Commit "Placeholder"
+<#
+.SYNOPSIS
+    Builds the Editor Packed Library (.lvlibp) using g-cli.
+
+.DESCRIPTION
+    Invokes the LabVIEW build specification "Editor Packed Library" through
+    g-cli, embedding the provided version information and commit identifier.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used for the build.
+
+.PARAMETER SupportedBitness
+    Bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root where the project file resides.
+
+.PARAMETER Major
+    Major version component for the PPL.
+
+.PARAMETER Minor
+    Minor version component for the PPL.
+
+.PARAMETER Patch
+    Patch version component for the PPL.
+
+.PARAMETER Build
+    Build number component for the PPL.
+
+.PARAMETER Commit
+    Commit hash or identifier recorded in the build.
+
+.EXAMPLE
+    .\Build_lvlibp.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -Major 1 -Minor 0 -Patch 0 -Build 0 -Commit "Placeholder"
+#>
 param(
     [string]$MinimumSupportedLVVersion,
     [string]$SupportedBitness,
@@ -32,3 +66,4 @@ if ($LASTEXITCODE -ne 0) {
     Write-Host "Build succeeded."
     exit 0
 }
+

--- a/pipeline/scripts/Cleanup.ps1
+++ b/pipeline/scripts/Cleanup.ps1
@@ -1,4 +1,30 @@
-#Example: .\RestoreSetupLVSource.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library" 
+<#
+.SYNOPSIS
+    Cleans up the LabVIEW setup after builds.
+
+.DESCRIPTION
+    Calls RestoreSetupLVSource.vi through g-cli to undo temporary configuration
+    and remove the Localhost.LibraryPaths token, returning LabVIEW to its
+    default state.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used to run g-cli.
+
+.PARAMETER SupportedBitness
+    Bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER LabVIEW_Project
+    Name of the LabVIEW project (without extension).
+
+.PARAMETER Build_Spec
+    Build specification name within the project.
+
+.EXAMPLE
+    .\Cleanup.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library"
+#>
 param(
     [string]$MinimumSupportedLVVersion,
     [string]$SupportedBitness,

--- a/pipeline/scripts/Close_LabVIEW.ps1
+++ b/pipeline/scripts/Close_LabVIEW.ps1
@@ -1,4 +1,20 @@
-#Example: .\Close_LabVIEW.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64"
+<#
+.SYNOPSIS
+    Gracefully closes a running LabVIEW instance.
+
+.DESCRIPTION
+    Utilizes g-cli's QuitLabVIEW command to shut down the specified LabVIEW
+    version and bitness, ensuring the application exits cleanly.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version to close (e.g., "2021").
+
+.PARAMETER SupportedBitness
+    Bitness of the LabVIEW instance ("32" or "64").
+
+.EXAMPLE
+    .\Close_LabVIEW.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64"
+#>
 param(
     [string]$MinimumSupportedLVVersion,
     [string]$SupportedBitness
@@ -27,3 +43,4 @@ try {
 }
 
 Write-Host "Close LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)"
+

--- a/pipeline/scripts/ModifyVIPBDisplayInfo.ps1
+++ b/pipeline/scripts/ModifyVIPBDisplayInfo.ps1
@@ -1,35 +1,49 @@
 <#
-This PowerShell script automates the process of updating a LabVIEW VIPB file’s 
-“Display Information” fields using the given JSON data and then builds the 
-VI Package via g-cli.
+.SYNOPSIS
+    Updates display information in a VIPB file and rebuilds the VI package.
 
-Key Steps:
-1. Resolves paths for your VIPB file and LabVIEW project directory.
-2. (Optionally) creates the release notes file if it does not exist.
-3. Calculates the final LabVIEW version string (e.g., "21.0 (64-bit)").
-4. Parses and updates the DisplayInformationJSON ("Package Version" field) 
-   with Major, Minor, Patch, Build from script parameters.
-5. Calls a LabVIEW VI (via g-cli) to update the VIPB file’s display information 
-   using the updated JSON.
-6. Builds the VI Package (again via g-cli), injecting the same version info 
-   (major, minor, patch, build) and release notes.
-7. Handles errors by outputting error details in JSON format.
+.DESCRIPTION
+    Resolves paths, merges version data into the DisplayInformation JSON, and
+    calls g-cli to update and build the package defined by the VIPB file.
 
-Example Usage:
-.\ModifyVIPBDisplayInfo.ps1 `
-  -SupportedBitness "64" `
-  -RelativePath "C:\release\labview-icon-editor-fork" `
-  -VIPBPath "Tooling\deployment\NI Icon editor.vipb" `
-  -MinimumSupportedLVVersion 2023 `
-  -LabVIEWMinorRevision 3 `
-  -Major 1 `
-  -Minor 0 `
-  -Patch 0 `
-  -Build 2 `
-  -Commit "Placeholder" `
-  -ReleaseNotesFile "C:\release\labview-icon-editor-fork\Tooling\deployment\release_notes.md" `
-  -DisplayInformationJSON '{"Package Version":{"major":0,"minor":0,"patch":0,"build":0},"Product Name":"","Company Name":"","Author Name (Person or Company)":"","Product Homepage (URL)":"","Legal Copyright":"","License Agreement Name":"","Product Description Summary":"","Product Description":"","Release Notes - Change Log":""}'
+.PARAMETER SupportedBitness
+    LabVIEW bitness for the build ("32" or "64").
 
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER VIPBPath
+    Relative path to the VIPB file to modify.
+
+.PARAMETER MinimumSupportedLVVersion
+    Minimum LabVIEW version supported by the package.
+
+.PARAMETER LabVIEWMinorRevision
+    Minor revision number of LabVIEW (0 or 3).
+
+.PARAMETER Major
+    Major version component for the package.
+
+.PARAMETER Minor
+    Minor version component for the package.
+
+.PARAMETER Patch
+    Patch version component for the package.
+
+.PARAMETER Build
+    Build number component for the package.
+
+.PARAMETER Commit
+    Commit identifier embedded in the package metadata.
+
+.PARAMETER ReleaseNotesFile
+    Path to a release notes file injected into the build.
+
+.PARAMETER DisplayInformationJSON
+    JSON string representing the VIPB display information to update.
+
+.EXAMPLE
+    .\ModifyVIPBDisplayInfo.ps1 -SupportedBitness "64" -RelativePath "C:\repo" -VIPBPath "Tooling\deployment\NI Icon editor.vipb" -MinimumSupportedLVVersion 2023 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit "abcd123" -ReleaseNotesFile "Tooling\deployment\release_notes.md" -DisplayInformationJSON '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
 #>
 param (
     [string]$SupportedBitness,

--- a/pipeline/scripts/Prepare_LabVIEW_source.ps1
+++ b/pipeline/scripts/Prepare_LabVIEW_source.ps1
@@ -1,5 +1,30 @@
-# Example usage:
-# .\Prepare_LabVIEW_source.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview icon editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library"
+<#
+.SYNOPSIS
+    Prepares LabVIEW source code for building.
+
+.DESCRIPTION
+    Executes the PrepareIESource.vi via g-cli to unzip required components and
+    update the LabVIEW configuration, ensuring the project is ready for
+    subsequent build steps.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used by g-cli.
+
+.PARAMETER SupportedBitness
+    Target bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root containing the project.
+
+.PARAMETER LabVIEW_Project
+    Name of the LabVIEW project (without extension).
+
+.PARAMETER Build_Spec
+    Name of the build specification to prepare.
+
+.EXAMPLE
+    .\Prepare_LabVIEW_source.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview icon editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library"
+#>
 
 param(
     [Parameter(Mandatory = $true)]
@@ -50,3 +75,4 @@ try {
     Write-Error "Please check the parameters and ensure the command is valid."
     exit 1
 }
+

--- a/pipeline/scripts/Rename-file.ps1
+++ b/pipeline/scripts/Rename-file.ps1
@@ -1,4 +1,20 @@
-#.\Rename-File.ps1 -CurrentFilename $RelativePath\resource\plugins\lv_icon.lvlibp -NewFilename $lv_icon_x64.lvlibp
+<#
+.SYNOPSIS
+    Renames a specified file.
+
+.DESCRIPTION
+    Checks whether the source file exists and, if so, renames it to the
+    provided target name.
+
+.PARAMETER CurrentFilename
+    Full path to the file to rename.
+
+.PARAMETER NewFilename
+    New name (including path) for the renamed file.
+
+.EXAMPLE
+    .\Rename-file.ps1 -CurrentFilename "C:\path\lv_icon.lvlibp" -NewFilename "lv_icon_x64.lvlibp"
+#>
 param(
     [string]$CurrentFilename,
     [string]$NewFilename
@@ -28,3 +44,4 @@ function Rename-File {
 
 # Call the function
 Rename-File -CurrentFilename $CurrentFilename -NewFilename $NewFilename
+

--- a/pipeline/scripts/RestoreSetupLVSource.ps1
+++ b/pipeline/scripts/RestoreSetupLVSource.ps1
@@ -1,4 +1,29 @@
-#Example: .\RestoreSetupLVSource.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library" 
+<#
+.SYNOPSIS
+    Restores the LabVIEW source setup from a packaged state.
+
+.DESCRIPTION
+    Calls RestoreSetupLVSource.vi via g-cli to unzip the LabVIEW Icon API and
+    remove the Localhost.LibraryPaths token from the LabVIEW INI file.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used to run g-cli.
+
+.PARAMETER SupportedBitness
+    Bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER LabVIEW_Project
+    Name of the LabVIEW project (without extension).
+
+.PARAMETER Build_Spec
+    Build specification name within the project.
+
+.EXAMPLE
+    .\RestoreSetupLVSource.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library"
+#>
 param(
     [string]$MinimumSupportedLVVersion,
     [string]$SupportedBitness,

--- a/pipeline/scripts/RevertDevelopmentMode.ps1
+++ b/pipeline/scripts/RevertDevelopmentMode.ps1
@@ -1,5 +1,17 @@
-# Example usage:
-# .\RevertDevelopmentMode.ps1 -RelativePath "C:\labview-icon-editor"
+<#
+.SYNOPSIS
+    Reverts the repository from development mode.
+
+.DESCRIPTION
+    Restores the packaged LabVIEW sources for both 32-bit and 64-bit
+    environments and closes any running LabVIEW instances.
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.EXAMPLE
+    .\RevertDevelopmentMode.ps1 -RelativePath "C:\labview-icon-editor"
+#>
 
 param(
     [Parameter(Mandatory = $true)]
@@ -67,3 +79,4 @@ try {
 }
 
 Write-Host "All scripts executed successfully." -ForegroundColor Green
+

--- a/pipeline/scripts/Set_Development_Mode.ps1
+++ b/pipeline/scripts/Set_Development_Mode.ps1
@@ -1,6 +1,17 @@
+<#
+.SYNOPSIS
+    Configures the repository for development mode.
 
-# Example usage:
-# .\Set_Development_Mode.ps1 -RelativePath "C:\labview-icon-editor"
+.DESCRIPTION
+    Removes existing packed libraries, adds INI tokens, prepares LabVIEW
+    sources for both 32-bit and 64-bit environments, and closes LabVIEW.
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.EXAMPLE
+    .\Set_Development_Mode.ps1 -RelativePath "C:\labview-icon-editor"
+#>
 
 param(
     [string]$RelativePath
@@ -35,3 +46,4 @@ try {
 }
 
 Write-Host "All scripts executed successfully."
+

--- a/pipeline/scripts/build_vip.ps1
+++ b/pipeline/scripts/build_vip.ps1
@@ -1,35 +1,49 @@
 <#
-This PowerShell script automates the process of updating a LabVIEW VIPB file’s 
-“Display Information” fields using the given JSON data and then builds the 
-VI Package via g-cli.
+.SYNOPSIS
+    Updates a VIPB file's display information and builds the VI package.
 
-Key Steps:
-1. Resolves paths for your VIPB file and LabVIEW project directory.
-2. (Optionally) creates the release notes file if it does not exist.
-3. Calculates the final LabVIEW version string (e.g., "21.0 (64-bit)").
-4. Parses and updates the DisplayInformationJSON ("Package Version" field) 
-   with Major, Minor, Patch, Build from script parameters.
-5. Calls a LabVIEW VI (via g-cli) to update the VIPB file’s display information 
-   using the updated JSON.
-6. Builds the VI Package (again via g-cli), injecting the same version info 
-   (major, minor, patch, build) and release notes.
-7. Handles errors by outputting error details in JSON format.
+.DESCRIPTION
+    Resolves paths, merges version details into DisplayInformation JSON, and
+    calls g-cli to modify the VIPB file and create the final VI package.
 
-Example Usage:
-.\build_vip.ps1 `
-  -SupportedBitness "64" `
-  -RelativePath "C:\labview-icon-editor-fork" `
-  -VIPBPath "Tooling\deployment\NI Icon editor.vipb" `
-  -MinimumSupportedLVVersion 2021 `
-  -LabVIEWMinorRevision 3 `
-  -Major 1 `
-  -Minor 0 `
-  -Patch 0 `
-  -Build 2 `
-  -Commit "Placeholder" `
-  -ReleaseNotesFile "C:\labview-icon-editor-fork\Tooling\deployment\release_notes.md" `
-  -DisplayInformationJSON '{"Package Version":{"major":0,"minor":0,"patch":0,"build":0},"Product Name":"","Company Name":"","Author Name (Person or Company)":"","Product Homepage (URL)":"","Legal Copyright":"","License Agreement Name":"","Product Description Summary":"","Product Description":"","Release Notes - Change Log":""}'
+.PARAMETER SupportedBitness
+    LabVIEW bitness for the build ("32" or "64").
 
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER VIPBPath
+    Relative path to the VIPB file to update.
+
+.PARAMETER MinimumSupportedLVVersion
+    Minimum LabVIEW version supported by the package.
+
+.PARAMETER LabVIEWMinorRevision
+    Minor revision number of LabVIEW (0 or 3).
+
+.PARAMETER Major
+    Major version component for the package.
+
+.PARAMETER Minor
+    Minor version component for the package.
+
+.PARAMETER Patch
+    Patch version component for the package.
+
+.PARAMETER Build
+    Build number component for the package.
+
+.PARAMETER Commit
+    Commit identifier embedded in the package metadata.
+
+.PARAMETER ReleaseNotesFile
+    Path to a release notes file injected into the build.
+
+.PARAMETER DisplayInformationJSON
+    JSON string representing the VIPB display information to update.
+
+.EXAMPLE
+    .\build_vip.ps1 -SupportedBitness "64" -RelativePath "C:\repo" -VIPBPath "Tooling\deployment\NI Icon editor.vipb" -MinimumSupportedLVVersion 2021 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit "abcd123" -ReleaseNotesFile "Tooling\deployment\release_notes.md" -DisplayInformationJSON '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
 #>
 
 param (
@@ -142,3 +156,4 @@ catch {
     $errorObject | ConvertTo-Json -Depth 10
     exit 1
 }
+

--- a/pipeline/scripts/unit_tests.ps1
+++ b/pipeline/scripts/unit_tests.ps1
@@ -1,4 +1,20 @@
-# .\unit_tests.ps1 -RelativePath "C:\labview-icon-editor" -AbsolutePathScripts "C:\labview-icon-editor\pipeline\scripts"
+<#
+.SYNOPSIS
+    Runs a suite of PowerShell test scripts for the repository.
+
+.DESCRIPTION
+    Validates that required paths exist and sequentially executes supporting
+    scripts to prepare and test the LabVIEW icon editor project.
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER AbsolutePathScripts
+    Absolute path to the pipeline scripts directory.
+
+.EXAMPLE
+    .\unit_tests.ps1 -RelativePath "C:\labview-icon-editor" -AbsolutePathScripts "C:\labview-icon-editor\pipeline\scripts"
+#>
 param(
     [Parameter(Mandatory = $true)]
     [string]$RelativePath,
@@ -80,3 +96,4 @@ try {
     Write-Host "An unexpected error occurred during script execution: $($_.Exception.Message)" -ForegroundColor Red
     exit 1
 }
+


### PR DESCRIPTION
## Summary
- add comment-based help to pipeline PowerShell scripts for clearer usage and parameters

## Testing
- `pwsh -NoProfile -File pipeline/scripts/RunUnitTests.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 64` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689122ab34988329bca8bff9c8f37343