### PR TITLE
chore(actions): embed scripts and drop scripts_folder

### DIFF
--- a/.github/actions/add-token-to-labview/AddTokenToLabVIEW.ps1
+++ b/.github/actions/add-token-to-labview/AddTokenToLabVIEW.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Adds a custom library path token to the LabVIEW INI file.
+
+.DESCRIPTION
+    Uses g-cli to call Create_LV_INI_Token.vi, inserting the provided path into
+    the LabVIEW INI file under the Localhost.LibraryPaths token. This enables
+    LabVIEW to locate local project libraries during development or builds.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used by g-cli (e.g., "2021").
+
+.PARAMETER SupportedBitness
+    Target bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root that should be added to the INI token.
+
+.EXAMPLE
+    .\AddTokenToLabVIEW.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor"
+#>
+
+param(
+    [string]$MinimumSupportedLVVersion,
+    [string]$SupportedBitness,
+    [string]$RelativePath
+)
+
+# Construct the command
+$script = @"
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness -v "$RelativePath\Tooling\deployment\Create_LV_INI_Token.vi" -- "LabVIEW" "Localhost.LibraryPaths" "$RelativePath"
+"@
+
+Write-Output "Executing the following command:"
+Write-Output $script
+
+# Execute the command and check for errors
+try {
+    Invoke-Expression $script
+
+    # Check the exit code of the executed command
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Create localhost.library path from ini file"
+    }
+} catch {
+    Write-Host ""
+    exit 0
+}

--- a/.github/actions/add-token-to-labview/README.md
+++ b/.github/actions/add-token-to-labview/README.md
@@ -8,7 +8,6 @@ Invoke **`AddTokenToLabVIEW.ps1`** through a composite action to add a `Localhos
 | `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version used by g-cli. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `AddTokenToLabVIEW.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -17,7 +16,6 @@ Invoke **`AddTokenToLabVIEW.ps1`** through a composite action to add a `Localhos
     minimum_supported_lv_version: 2024
     supported_bitness: 64
     relative_path: ${{ github.workspace }}
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/add-token-to-labview/action.yml
+++ b/.github/actions/add-token-to-labview/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run AddTokenToLabVIEW.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/AddTokenToLabVIEW.ps1" \
+        & "${{ github.action_path }}/AddTokenToLabVIEW.ps1" \
           -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RelativePath "${{ inputs.relative_path }}"
@@ -24,7 +24,4 @@ inputs:
     required: true
   relative_path:
     description: 'Workspace root path'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/apply-vipc/ApplyVIPC.ps1
+++ b/.github/actions/apply-vipc/ApplyVIPC.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+    Applies a .vipc file to a given LabVIEW version/bitness.
+    This version includes additional debug/verbose output.
+
+.EXAMPLE
+    .\applyvipc.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\release\labview-icon-editor-fork" -VIPCPath "Tooling\deployment\runner_dependencies.vipc" -VIP_LVVersion "2021" -Verbose
+#>
+
+[CmdletBinding()]  # Enables -Verbose and other common parameters
+Param (
+    [string]$MinimumSupportedLVVersion,
+    [string]$VIP_LVVersion,
+    [string]$SupportedBitness,
+    [string]$RelativePath,
+    [string]$VIPCPath
+)
+
+Write-Verbose "Script Name: $($MyInvocation.MyCommand.Definition)"
+Write-Verbose "Parameters provided:"
+Write-Verbose " - MinimumSupportedLVVersion: $MinimumSupportedLVVersion"
+Write-Verbose " - VIP_LVVersion:             $VIP_LVVersion"
+Write-Verbose " - SupportedBitness:          $SupportedBitness"
+Write-Verbose " - RelativePath:              $RelativePath"
+Write-Verbose " - VIPCPath:                  $VIPCPath"
+
+# -------------------------
+# 1) Resolve Paths & Validate
+# -------------------------
+try {
+    Write-Verbose "Attempting to resolve the 'RelativePath'..."
+    $ResolvedRelativePath = Resolve-Path -Path $RelativePath -ErrorAction Stop
+    Write-Verbose "ResolvedRelativePath: $ResolvedRelativePath"
+
+    Write-Verbose "Building full path for the .vipc file..."
+    $ResolvedVIPCPath = Join-Path -Path $ResolvedRelativePath -ChildPath $VIPCPath -ErrorAction Stop
+    Write-Verbose "ResolvedVIPCPath:     $ResolvedVIPCPath"
+
+    # Verify that the .vipc file actually exists
+    Write-Verbose "Checking if the .vipc file exists at the resolved path..."
+    if (-not (Test-Path $ResolvedVIPCPath)) {
+        Write-Error "The .vipc file does not exist at '$ResolvedVIPCPath'."
+        exit 1
+    }
+    Write-Verbose "The .vipc file was found successfully."
+}
+catch {
+    Write-Error "Error resolving paths. Ensure RelativePath and VIPCPath are valid. Details: $($_.Exception.Message)"
+    exit 1
+}
+
+# -------------------------
+# 2) Build LabVIEW Version Strings
+# -------------------------
+Write-Verbose "Determining LabVIEW version strings..."
+switch ("$VIP_LVVersion-$SupportedBitness") {
+    "2021-64" { $VIP_LVVersion_A = "21.0 (64-bit)" }
+    "2021-32" { $VIP_LVVersion_A = "21.0" }
+    "2022-64" { $VIP_LVVersion_A = "22.3 (64-bit)" }
+    "2022-32" { $VIP_LVVersion_A = "22.3" }
+    "2023-64" { $VIP_LVVersion_A = "23.3 (64-bit)" }
+    "2023-32" { $VIP_LVVersion_A = "23.3" }
+    "2024-64" { $VIP_LVVersion_A = "24.3 (64-bit)" }
+    "2024-32" { $VIP_LVVersion_A = "24.3" }
+    "2025-64" { $VIP_LVVersion_A = "25.3 (64-bit)" }
+    "2025-32" { $VIP_LVVersion_A = "25.3" }
+    default {
+        Write-Error "Unsupported VIP_LVVersion or SupportedBitness for VIP_LVVersion_A."
+        exit 1
+    }
+}
+
+switch ("$MinimumSupportedLVVersion-$SupportedBitness") {
+    "2021-64" { $VIP_LVVersion_B = "21.0 (64-bit)" }
+    "2021-32" { $VIP_LVVersion_B = "21.0" }
+    "2022-64" { $VIP_LVVersion_B = "22.3 (64-bit)" }
+    "2022-32" { $VIP_LVVersion_B = "22.3" }
+    "2023-64" { $VIP_LVVersion_B = "23.3 (64-bit)" }
+    "2023-32" { $VIP_LVVersion_B = "23.3" }
+    "2024-64" { $VIP_LVVersion_B = "24.3 (64-bit)" }
+    "2024-32" { $VIP_LVVersion_B = "24.3" }
+    "2025-64" { $VIP_LVVersion_B = "25.3 (64-bit)" }
+    "2025-32" { $VIP_LVVersion_B = "25.3" }
+    default {
+        Write-Error "Unsupported MinimumSupportedLVVersion or SupportedBitness for VIP_LVVersion_B."
+        exit 1
+    }
+}
+
+Write-Output "Applying dependencies for LabVIEW $VIP_LVVersion_B..."
+Write-Verbose "VIP_LVVersion_A (for primary LVVersion): $VIP_LVVersion_A"
+Write-Verbose "VIP_LVVersion_B (for minimum LVVersion): $VIP_LVVersion_B"
+
+# -------------------------
+# 3) Construct the Script to Execute
+# -------------------------
+Write-Verbose "Constructing the g-cli command script..."
+$script = @"
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness -v "$($ResolvedRelativePath)\Tooling\Deployment\Applyvipc.vi" -- "$ResolvedVIPCPath" "$VIP_LVVersion_B"
+"@
+
+if ($VIP_LVVersion -ne $MinimumSupportedLVVersion) {
+    Write-Verbose "VIP_LVVersion and MinimumSupportedLVVersion differ; adding commands for $VIP_LVVersion..."
+    $script += @"
+g-cli vipc -- -t 3000 -v "$VIP_LVVersion" "$ResolvedVIPCPath"
+"@
+}
+
+# -------------------------
+# 4) Output the script for debugging
+# -------------------------
+Write-Output "Executing the following commands:"
+Write-Output $script
+Write-Verbose "Full script content (for debugging): `n$script"
+
+# -------------------------
+# 5) Execute the Script & Handle Errors (Try/Catch with Invoke-Expression)
+# -------------------------
+try {
+    Write-Verbose "Starting Invoke-Expression to run g-cli commands..."
+    Invoke-Expression $script
+    Write-Host "Successfully applied dependencies to LabVIEW: $VIP_LVVersion_B" `
+        " (and potentially $VIP_LVVersion_A if switched)."
+}
+catch {
+    Write-Error "An error occurred while applying the .vipc dependencies. Details: $($_.Exception.Message)"
+    exit 1
+}

--- a/.github/actions/apply-vipc/README.md
+++ b/.github/actions/apply-vipc/README.md
@@ -21,7 +21,6 @@ Ensure a runner has all required LabVIEW packages installed before building or t
 | **LabVIEW** `>= 2021` | Must match both `minimum_supported_lv_version` and `vip_lv_version`. |
 | **g-cli** in `PATH` | Used to apply the `.vipc` container. Install from NI Package Manager or include the executable in the runner image. |
 | **PowerShell 7** | Composite steps use PowerShell Core (`pwsh`). |
-| Access to `ApplyVIPC.ps1` | Provide the folder containing the script via `scripts_folder`. |
 
 ---
 
@@ -32,7 +31,6 @@ Ensure a runner has all required LabVIEW packages installed before building or t
 | `vip_lv_version` | **Yes** | `2021` | LabVIEW version used to apply the `.vipc` file. Usually the same as `minimum_supported_lv_version`. |
 | `supported_bitness` | **Yes** | `32` or `64` | LabVIEW bitness to target. |
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Root path of the repository on disk. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `ApplyVIPC.ps1`. |
 | `vipc_path` | **Yes** | `Tooling/deployment/runner_dependencies.vipc` | Path (relative to `relative_path`) of the container to apply. |
 
 ---
@@ -49,7 +47,6 @@ steps:
       vip_lv_version: 2024
       supported_bitness: 64
       relative_path: ${{ github.workspace }}
-      scripts_folder: pipeline/scripts
       vipc_path: Tooling/deployment/runner_dependencies.vipc
 ```
 

--- a/.github/actions/apply-vipc/action.yml
+++ b/.github/actions/apply-vipc/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run ApplyVIPC.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/ApplyVIPC.ps1" `
+        & "${{ github.action_path }}/ApplyVIPC.ps1" `
           -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
           -VIP_LVVersion ${{ inputs.vip_lv_version }} `
           -SupportedBitness ${{ inputs.supported_bitness }} `
@@ -29,9 +29,6 @@ inputs:
     required: true
   relative_path:
     description: 'Workspace root path'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true
   vipc_path:
     description: 'Path under repo for the .vipc file (relative to workspace)'

--- a/.github/actions/build-lvlibp/Build_lvlibp.ps1
+++ b/.github/actions/build-lvlibp/Build_lvlibp.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+    Builds the Editor Packed Library (.lvlibp) using g-cli.
+
+.DESCRIPTION
+    Invokes the LabVIEW build specification "Editor Packed Library" through
+    g-cli, embedding the provided version information and commit identifier.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used for the build.
+
+.PARAMETER SupportedBitness
+    Bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root where the project file resides.
+
+.PARAMETER Major
+    Major version component for the PPL.
+
+.PARAMETER Minor
+    Minor version component for the PPL.
+
+.PARAMETER Patch
+    Patch version component for the PPL.
+
+.PARAMETER Build
+    Build number component for the PPL.
+
+.PARAMETER Commit
+    Commit hash or identifier recorded in the build.
+
+.EXAMPLE
+    .\Build_lvlibp.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -Major 1 -Minor 0 -Patch 0 -Build 0 -Commit "Placeholder"
+#>
+param(
+    [string]$MinimumSupportedLVVersion,
+    [string]$SupportedBitness,
+    [string]$RelativePath,
+    [Int32]$Major,
+    [Int32]$Minor,
+    [Int32]$Patch,
+    [Int32]$Build,
+    [string]$Commit
+)
+
+Write-Output "PPL Version: $Major.$Minor.$Patch.$Build"
+Write-Output "Commit: $Commit"
+
+# Construct the command
+$script = @"
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness lvbuildspec -- -v "$Major.$Minor.$Patch.$Build" -p "$RelativePath\lv_icon_editor.lvproj" -b "Editor Packed Library"
+"@
+Write-Output "Executing the following command:"
+Write-Output $script
+
+# Execute the command
+Invoke-Expression $script
+
+# Check the exit code
+if ($LASTEXITCODE -ne 0) {
+    g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness QuitLabVIEW
+    Write-Host "Build failed with exit code $LASTEXITCODE."
+    exit 1
+} else {
+    Write-Host "Build succeeded."
+    exit 0
+}
+

--- a/.github/actions/build-lvlibp/README.md
+++ b/.github/actions/build-lvlibp/README.md
@@ -13,7 +13,6 @@ Call **`Build_lvlibp.ps1`** to compile the editor packed library using g-cli.
 | `patch` | **Yes** | `0` | Patch version component. |
 | `build` | **Yes** | `1` | Build number component. |
 | `commit` | **Yes** | `abcdef` | Commit identifier. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `Build_lvlibp.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -27,7 +26,6 @@ Call **`Build_lvlibp.ps1`** to compile the editor packed library using g-cli.
     patch: 0
     build: 1
     commit: ${{ github.sha }}
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/build-lvlibp/action.yml
+++ b/.github/actions/build-lvlibp/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run Build_lvlibp.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/Build_lvlibp.ps1" \
+        & "${{ github.action_path }}/Build_lvlibp.ps1" \
           -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RelativePath "${{ inputs.relative_path }}" \
@@ -44,7 +44,4 @@ inputs:
     required: true
   commit:
     description: 'Commit identifier'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/build-vip/README.md
+++ b/.github/actions/build-vip/README.md
@@ -17,7 +17,6 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
 | `commit` | **Yes** | `abcdef` | Commit identifier. |
 | `release_notes_file` | **Yes** | `Tooling/deployment/release_notes.md` | Release notes file. |
 | `display_information_json` | **Yes** | `'{}'` | JSON for VIPB display information. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `build_vip.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -34,7 +33,6 @@ Runs **`build_vip.ps1`** to update a `.vipb` file's display info and build the V
     commit: ${{ github.sha }}
     release_notes_file: Tooling/deployment/release_notes.md
     display_information_json: '{}'
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run build_vip.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/build_vip.ps1" \
+        & "${{ github.action_path }}/build_vip.ps1" \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RelativePath "${{ inputs.relative_path }}" \
           -VIPBPath "${{ inputs.vipb_path }}" \
@@ -61,7 +61,4 @@ inputs:
     required: true
   display_information_json:
     description: 'DisplayInformation JSON string'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/build-vip/build_vip.ps1
+++ b/.github/actions/build-vip/build_vip.ps1
@@ -1,0 +1,159 @@
+<#
+.SYNOPSIS
+    Updates a VIPB file's display information and builds the VI package.
+
+.DESCRIPTION
+    Resolves paths, merges version details into DisplayInformation JSON, and
+    calls g-cli to modify the VIPB file and create the final VI package.
+
+.PARAMETER SupportedBitness
+    LabVIEW bitness for the build ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER VIPBPath
+    Relative path to the VIPB file to update.
+
+.PARAMETER MinimumSupportedLVVersion
+    Minimum LabVIEW version supported by the package.
+
+.PARAMETER LabVIEWMinorRevision
+    Minor revision number of LabVIEW (0 or 3).
+
+.PARAMETER Major
+    Major version component for the package.
+
+.PARAMETER Minor
+    Minor version component for the package.
+
+.PARAMETER Patch
+    Patch version component for the package.
+
+.PARAMETER Build
+    Build number component for the package.
+
+.PARAMETER Commit
+    Commit identifier embedded in the package metadata.
+
+.PARAMETER ReleaseNotesFile
+    Path to a release notes file injected into the build.
+
+.PARAMETER DisplayInformationJSON
+    JSON string representing the VIPB display information to update.
+
+.EXAMPLE
+    .\build_vip.ps1 -SupportedBitness "64" -RelativePath "C:\repo" -VIPBPath "Tooling\deployment\NI Icon editor.vipb" -MinimumSupportedLVVersion 2021 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit "abcd123" -ReleaseNotesFile "Tooling\deployment\release_notes.md" -DisplayInformationJSON '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
+#>
+
+param (
+    [string]$SupportedBitness,
+    [string]$RelativePath,
+    [string]$VIPBPath,
+
+    [int]$MinimumSupportedLVVersion,
+
+    [ValidateSet("0","3")]
+    [string]$LabVIEWMinorRevision = "0",
+
+    [int]$Major,
+    [int]$Minor,
+    [int]$Patch,
+    [int]$Build,
+    [string]$Commit,
+    [string]$ReleaseNotesFile,
+
+    [Parameter(Mandatory=$true)]
+    [string]$DisplayInformationJSON
+)
+
+# 1) Resolve paths
+try {
+    $ResolvedRelativePath = Resolve-Path -Path $RelativePath -ErrorAction Stop
+    $ResolvedVIPBPath = Join-Path -Path $ResolvedRelativePath -ChildPath $VIPBPath -ErrorAction Stop
+}
+catch {
+    $errorObject = [PSCustomObject]@{
+        error      = "Error resolving paths. Ensure RelativePath and VIPBPath are valid."
+        exception  = $_.Exception.Message
+        stackTrace = $_.Exception.StackTrace
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+
+# 2) Create release notes if needed
+if (-not (Test-Path $ReleaseNotesFile)) {
+    Write-Host "Release notes file '$ReleaseNotesFile' does not exist. Creating it..."
+    New-Item -ItemType File -Path $ReleaseNotesFile -Force | Out-Null
+}
+
+# 3) Calculate the LabVIEW version string
+$lvNumericMajor    = $MinimumSupportedLVVersion - 2000
+$lvNumericVersion  = "$($lvNumericMajor).$LabVIEWMinorRevision"
+if ($SupportedBitness -eq "64") {
+    $VIP_LVVersion_A = "$lvNumericVersion (64-bit)"
+}
+else {
+    $VIP_LVVersion_A = $lvNumericVersion
+}
+Write-Output "Building VI Package for LabVIEW $VIP_LVVersion_A..."
+
+# 4) Parse and update the DisplayInformationJSON
+try {
+    $jsonObj = $DisplayInformationJSON | ConvertFrom-Json
+}
+catch {
+    $errorObject = [PSCustomObject]@{
+        error      = "Failed to parse DisplayInformationJSON into valid JSON."
+        exception  = $_.Exception.Message
+        stackTrace = $_.Exception.StackTrace
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+
+# If "Package Version" doesn't exist, create it as a subobject
+if (-not $jsonObj.'Package Version') {
+    $jsonObj | Add-Member -MemberType NoteProperty -Name 'Package Version' -Value ([PSCustomObject]@{
+        major = $Major
+        minor = $Minor
+        patch = $Patch
+        build = $Build
+    })
+}
+else {
+    # "Package Version" exists, so just overwrite its fields
+    $jsonObj.'Package Version'.major = $Major
+    $jsonObj.'Package Version'.minor = $Minor
+    $jsonObj.'Package Version'.patch = $Patch
+    $jsonObj.'Package Version'.build = $Build
+}
+
+# Re-convert to a JSON string with a comfortable nesting depth
+$UpdatedDisplayInformationJSON = $jsonObj | ConvertTo-Json -Depth 5
+
+# 5) Construct the command script
+
+$script = @"
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness vipb -- --buildspec "$ResolvedVIPBPath" -v "$Major.$Minor.$Patch.$Build" --release-notes "$ReleaseNotesFile" --timeout 300
+"@
+
+Write-Output "Executing the following commands:"
+Write-Output $script
+
+# 6) Execute the commands
+try {
+    Invoke-Expression $script
+    Write-Host "Successfully built VI package: $ResolvedVIPBPath"
+}
+catch {
+    $errorObject = [PSCustomObject]@{
+        error      = "An error occurred while executing the build commands."
+        exception  = $_.Exception.Message
+        stackTrace = $_.Exception.StackTrace
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+

--- a/.github/actions/build/Build.ps1
+++ b/.github/actions/build/Build.ps1
@@ -1,0 +1,269 @@
+<#
+.SYNOPSIS
+  This script automates the build process for the LabVIEW Icon Editor project.
+  It performs the following tasks:
+    1. Cleans up old .lvlibp files in the plugins folder.
+    2. Applies VIPC (32-bit and 64-bit).
+    3. Builds the LabVIEW library (32-bit and 64-bit).
+    4. Closes LabVIEW (32-bit and 64-bit).
+    5. Renames the built files.
+    6. Builds the VI package (64-bit) with DisplayInformationJSON fields.
+    7. Closes LabVIEW (64-bit).
+
+  Example usage:
+    .\Build.ps1 `
+      -RelativePath "C:\release\labview-icon-editor-fork" `
+      -AbsolutePathScripts "C:\release\labview-icon-editor-fork\pipeline\scripts" `
+      -Major 1 -Minor 0 -Patch 0 -Build 3 -Commit "Placeholder" `
+      -CompanyName "Acme Corporation" `
+      -AuthorName "John Doe (Acme Corp)" `
+      -Verbose
+#>
+
+[CmdletBinding()]  # Enables -Verbose, -Debug, etc.
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RelativePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AbsolutePathScripts,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Major = 1,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Minor,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Patch,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Build,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Commit,
+
+    # LabVIEW "minor" revision (0 or 3)
+    [Parameter(Mandatory = $false)]
+    [int]$LabVIEWMinorRevision = 3,
+
+    # New parameters that will populate the JSON fields
+    [Parameter(Mandatory = $true)]
+    [string]$CompanyName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AuthorName
+)
+
+# Helper function to verify a file/folder path exists
+function Assert-PathExists {
+    param(
+        [string]$Path,
+        [string]$Description
+    )
+    Write-Verbose "Checking if '$Description' exists at path: $Path"
+    if (-not (Test-Path -Path $Path)) {
+        Write-Host "The '$Description' does not exist: $Path" -ForegroundColor Red
+        exit 1
+    }
+    Write-Verbose "Confirmed '$Description' exists at path: $Path"
+}
+
+# Helper function to run another script with arguments
+function Execute-Script {
+    param(
+        [string]$ScriptPath,
+        [string]$Arguments
+    )
+    Write-Host "Executing: $ScriptPath $Arguments" -ForegroundColor Cyan
+    Write-Verbose "Constructing command line..."
+    
+    # The & symbol explicitly invokes the script file
+    $command = "& `"$ScriptPath`" $Arguments"
+    Write-Verbose "Command: $command"
+
+    try {
+        Invoke-Expression $command
+        Write-Verbose "Command completed. Checking exit code..."
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Error occurred while executing: `"$ScriptPath`" with arguments: `"$Arguments`". Exit code: $LASTEXITCODE" -ForegroundColor Red
+            exit $LASTEXITCODE
+        }
+        Write-Verbose "Exit code is 0; no errors detected."
+    }
+    catch {
+        Write-Host "Error occurred while executing: `"$ScriptPath`" with arguments: `"$Arguments`". Exiting." -ForegroundColor Red
+        Write-Verbose "Exception details: $($_.Exception.Message)"
+        exit 1
+    }
+}
+
+try {
+    Write-Verbose "Script: Build.ps1 starting."
+    Write-Verbose "Parameters received:"
+    Write-Verbose " - RelativePath: $RelativePath"
+    Write-Verbose " - AbsolutePathScripts: $AbsolutePathScripts"
+    Write-Verbose " - Major: $Major"
+    Write-Verbose " - Minor: $Minor"
+    Write-Verbose " - Patch: $Patch"
+    Write-Verbose " - Build: $Build"
+    Write-Verbose " - Commit: $Commit"
+    Write-Verbose " - LabVIEWMinorRevision: $LabVIEWMinorRevision"
+    Write-Verbose " - CompanyName: $CompanyName"
+    Write-Verbose " - AuthorName: $AuthorName"
+
+    # Validate needed folders
+    Assert-PathExists $RelativePath "RelativePath"
+    Assert-PathExists "$RelativePath\resource\plugins" "Plugins folder"
+    Assert-PathExists $AbsolutePathScripts "Scripts folder"
+
+    # 1) Clean up old .lvlibp in the plugins folder
+    Write-Host "Cleaning up old .lvlibp files in plugins folder..." -ForegroundColor Yellow
+    Write-Verbose "Looking for .lvlibp files in $($RelativePath)\resource\plugins..."
+    try {
+        $PluginFiles = Get-ChildItem -Path "$RelativePath\resource\plugins" -Filter '*.lvlibp' -ErrorAction Stop
+        if ($PluginFiles) {
+            Write-Verbose "Found $($PluginFiles.Count) file(s): $($PluginFiles | ForEach-Object { $_.Name } -join ', ')"
+            $PluginFiles | Remove-Item -Force
+            Write-Host "Deleted .lvlibp files from plugins folder." -ForegroundColor Green
+        }
+        else {
+            Write-Host "No .lvlibp files found to delete." -ForegroundColor Cyan
+        }
+    }
+    catch {
+        Write-Host "Error occurred while retrieving .lvlibp files: $($_.Exception.Message)" -ForegroundColor Red
+        Write-Verbose "Stack Trace: $($_.Exception.StackTrace)"
+    }
+
+#    # 2) Apply VIPC (32-bit)
+#    Write-Verbose "Now applying VIPC for 32-bit..."
+#    Execute-Script "$($AbsolutePathScripts)\ApplyVIPC.ps1" `
+#        ("-MinimumSupportedLVVersion 2021 " +
+#         "-VIP_LVVersion 2021 " +
+#         "-SupportedBitness 32 " +
+#         "-RelativePath `"$RelativePath`" " +
+#         "-VIPCPath `"Tooling\deployment\runner_dependencies.vipc`"")
+
+    # 3) Build LV Library (32-bit)
+    Write-Verbose "Building LV library (32-bit)..."
+    Execute-Script "$($AbsolutePathScripts)\Build_lvlibp.ps1" `
+        ("-MinimumSupportedLVVersion 2021 " +
+         "-SupportedBitness 32 " +
+         "-RelativePath `"$RelativePath`" " +
+         "-Major $Major -Minor $Minor -Patch $Patch -Build $Build " +
+         "-Commit `"$Commit`"")
+
+    # 4) Close LabVIEW (32-bit)
+    Write-Verbose "Closing LabVIEW (32-bit)..."
+    Execute-Script "$($AbsolutePathScripts)\Close_LabVIEW.ps1" `
+        "-MinimumSupportedLVVersion 2021 -SupportedBitness 32"
+
+    # 5) Rename .lvlibp -> lv_icon_x86.lvlibp
+    Write-Verbose "Renaming .lvlibp file to lv_icon_x86.lvlibp..."
+    Execute-Script "$($AbsolutePathScripts)\Rename-File.ps1" `
+        "-CurrentFilename `"$RelativePath\resource\plugins\lv_icon.lvlibp`" -NewFilename 'lv_icon_x86.lvlibp'"
+
+ #   # 6) Apply VIPC (64-bit)
+ #   Write-Verbose "Now applying VIPC for 64-bit..."
+ #   Execute-Script "$($AbsolutePathScripts)\ApplyVIPC.ps1" `
+ #       ("-MinimumSupportedLVVersion 2021 " +
+ #        "-VIP_LVVersion 2021 " +
+ #        "-SupportedBitness 64 " +
+ #        "-RelativePath `"$RelativePath`" " +
+ #        "-VIPCPath `"Tooling\deployment\runner_dependencies.vipc`"")
+
+    # 7) Build LV Library (64-bit)
+    Write-Verbose "Building LV library (64-bit)..."
+    Execute-Script "$($AbsolutePathScripts)\Build_lvlibp.ps1" `
+        ("-MinimumSupportedLVVersion 2021 " +
+         "-SupportedBitness 64 " +
+         "-RelativePath `"$RelativePath`" " +
+         "-Major $Major -Minor $Minor -Patch $Patch -Build $Build " +
+         "-Commit `"$Commit`"")
+    
+    # 7.1) Close LabVIEW (64-bit)
+    Write-Verbose "Closing LabVIEW (64-bit)..."
+    Execute-Script "$($AbsolutePathScripts)\Close_LabVIEW.ps1" `
+        "-MinimumSupportedLVVersion 2021 -SupportedBitness 64"
+    
+
+    # Rename .lvlibp -> lv_icon_x64.lvlibp
+    Write-Verbose "Renaming .lvlibp file to lv_icon_x64.lvlibp..."
+    Execute-Script "$($AbsolutePathScripts)\Rename-File.ps1" `
+        "-CurrentFilename `"$RelativePath\resource\plugins\lv_icon.lvlibp`" -NewFilename 'lv_icon_x64.lvlibp'"
+
+    # -------------------------------------------------------------------------
+    # 8) Construct the JSON for "Company Name" & "Author Name", plus version
+    # -------------------------------------------------------------------------
+    # We include "Package Version" with your script parameters.
+    # The rest of the fields remain empty or default as needed.
+    $jsonObject = @{
+        "Package Version" = @{
+            "major" = $Major
+            "minor" = $Minor
+            "patch" = $Patch
+            "build" = $Build
+        }
+        "Product Name"                  = ""
+        "Company Name"                  = $CompanyName
+        "Author Name (Person or Company)" = $AuthorName
+        "Product Homepage (URL)"        = ""
+        "Legal Copyright"               = ""
+        "License Agreement Name"        = ""
+        "Product Description Summary"   = ""
+        "Product Description"           = ""
+        "Release Notes - Change Log"    = ""
+    }
+
+    $DisplayInformationJSON = $jsonObject | ConvertTo-Json -Depth 3
+
+    # 9) Modify VIPB Display Information
+    Write-Verbose "Modify VIPB Display Information (64-bit)..."
+    Execute-Script "$($AbsolutePathScripts)\ModifyVIPBDisplayInfo.ps1" `
+        (
+            # Use single-dash for all recognized parameters
+            "-SupportedBitness 64 " +
+            "-RelativePath `"$RelativePath`" " +
+            "-VIPBPath `"Tooling\deployment\NI Icon editor.vipb`" " +
+            "-MinimumSupportedLVVersion 2023 " +
+            "-LabVIEWMinorRevision $LabVIEWMinorRevision " +
+            "-Major $Major -Minor $Minor -Patch $Patch -Build $Build " +
+            "-Commit `"$Commit`" " +
+            "-ReleaseNotesFile `"$RelativePath\Tooling\deployment\release_notes.md`" " +
+            # Pass our JSON
+            "-DisplayInformationJSON '$DisplayInformationJSON' " +
+            "-Verbose"
+        )   
+
+    # 11) Build VI Package (64-bit) 2023
+    Write-Verbose "Building VI Package (64-bit)..."
+    Execute-Script "$($AbsolutePathScripts)\build_vip.ps1" `
+        (
+            # Use single-dash for all recognized parameters
+            "-SupportedBitness 64 " +
+            "-RelativePath `"$RelativePath`" " +
+            "-VIPBPath `"Tooling\deployment\NI Icon editor.vipb`" " +
+            "-MinimumSupportedLVVersion 2023 " +
+            "-LabVIEWMinorRevision $LabVIEWMinorRevision " +
+            "-Major $Major -Minor $Minor -Patch $Patch -Build $Build " +
+            "-Commit `"$Commit`" " +
+            "-ReleaseNotesFile `"$RelativePath\Tooling\deployment\release_notes.md`" " +
+            # Pass our JSON
+            "-DisplayInformationJSON '$DisplayInformationJSON' " +
+            "-Verbose"
+        )
+
+    # 12) Close LabVIEW (64-bit)
+    Write-Verbose "Closing LabVIEW (64-bit)..."
+    Execute-Script "$($AbsolutePathScripts)\Close_LabVIEW.ps1" `
+        "-MinimumSupportedLVVersion 2023 -SupportedBitness 64"
+
+    Write-Host "All scripts executed successfully!" -ForegroundColor Green
+    Write-Verbose "Script: Build.ps1 completed without errors."
+}
+catch {
+    Write-Host "An unexpected error occurred during script execution: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Verbose "Stack Trace: $($_.Exception.StackTrace)"
+    exit 1
+}

--- a/.github/actions/build/README.md
+++ b/.github/actions/build/README.md
@@ -6,7 +6,6 @@ Runs **`Build.ps1`** to clean, compile, and package the LabVIEW Icon Editor.
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root on disk. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `Build.ps1`. |
 | `major` | **Yes** | `1` | Major version number. |
 | `minor` | **Yes** | `0` | Minor version number. |
 | `patch` | **Yes** | `0` | Patch version number. |
@@ -21,7 +20,6 @@ Runs **`Build.ps1`** to clean, compile, and package the LabVIEW Icon Editor.
 - uses: ./.github/actions/build
   with:
     relative_path: ${{ github.workspace }}
-    scripts_folder: pipeline/scripts
     major: 1
     minor: 0
     patch: 0

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,9 +11,9 @@ runs:
     - name: Run Build.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/Build.ps1" \
+        & "${{ github.action_path }}/Build.ps1" \
           -RelativePath "${{ inputs.relative_path }}" \
-          -AbsolutePathScripts "${{ inputs.relative_path }}/${{ inputs.scripts_folder }}" \
+          -AbsolutePathScripts "${{ github.action_path }}" \
           -Major ${{ inputs.major }} \
           -Minor ${{ inputs.minor }} \
           -Patch ${{ inputs.patch }} \
@@ -25,9 +25,6 @@ runs:
 inputs:
   relative_path:
     description: 'Workspace root path'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true
   major:
     description: 'Major version'

--- a/.github/actions/close-labview/Close_LabVIEW.ps1
+++ b/.github/actions/close-labview/Close_LabVIEW.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+    Gracefully closes a running LabVIEW instance.
+
+.DESCRIPTION
+    Utilizes g-cli's QuitLabVIEW command to shut down the specified LabVIEW
+    version and bitness, ensuring the application exits cleanly.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version to close (e.g., "2021").
+
+.PARAMETER SupportedBitness
+    Bitness of the LabVIEW instance ("32" or "64").
+
+.EXAMPLE
+    .\Close_LabVIEW.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64"
+#>
+param(
+    [string]$MinimumSupportedLVVersion,
+    [string]$SupportedBitness
+)
+
+# Construct the command
+$script = @"
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness QuitLabVIEW
+"@
+
+Write-Output "Executing the following command:"
+Write-Output $script
+
+# Execute the command and check for errors
+try {
+    Invoke-Expression $script
+
+    # Check the exit code of the executed command
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to close LabVIEW with exit code $LASTEXITCODE."
+        exit $LASTEXITCODE
+    }
+} catch {
+    Write-Error "An error occurred while trying to close LabVIEW."
+    exit 1
+}
+
+Write-Host "Close LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)"
+

--- a/.github/actions/close-labview/README.md
+++ b/.github/actions/close-labview/README.md
@@ -7,7 +7,6 @@ Run **`Close_LabVIEW.ps1`** to terminate a running LabVIEW instance via g-cli.
 |------|----------|---------|-------------|
 | `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version to close. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `Close_LabVIEW.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -15,7 +14,6 @@ Run **`Close_LabVIEW.ps1`** to terminate a running LabVIEW instance via g-cli.
   with:
     minimum_supported_lv_version: 2024
     supported_bitness: 64
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/close-labview/action.yml
+++ b/.github/actions/close-labview/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run Close_LabVIEW.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/Close_LabVIEW.ps1" \
+        & "${{ github.action_path }}/Close_LabVIEW.ps1" \
           -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
           -SupportedBitness ${{ inputs.supported_bitness }}
 inputs:
@@ -20,7 +20,4 @@ inputs:
     required: true
   supported_bitness:
     description: '32 or 64'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
+++ b/.github/actions/modify-vipb-display-info/ModifyVIPBDisplayInfo.ps1
@@ -1,0 +1,162 @@
+<#
+.SYNOPSIS
+    Updates display information in a VIPB file and rebuilds the VI package.
+
+.DESCRIPTION
+    Resolves paths, merges version data into the DisplayInformation JSON, and
+    calls g-cli to update and build the package defined by the VIPB file.
+
+.PARAMETER SupportedBitness
+    LabVIEW bitness for the build ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER VIPBPath
+    Relative path to the VIPB file to modify.
+
+.PARAMETER MinimumSupportedLVVersion
+    Minimum LabVIEW version supported by the package.
+
+.PARAMETER LabVIEWMinorRevision
+    Minor revision number of LabVIEW (0 or 3).
+
+.PARAMETER Major
+    Major version component for the package.
+
+.PARAMETER Minor
+    Minor version component for the package.
+
+.PARAMETER Patch
+    Patch version component for the package.
+
+.PARAMETER Build
+    Build number component for the package.
+
+.PARAMETER Commit
+    Commit identifier embedded in the package metadata.
+
+.PARAMETER ReleaseNotesFile
+    Path to a release notes file injected into the build.
+
+.PARAMETER DisplayInformationJSON
+    JSON string representing the VIPB display information to update.
+
+.EXAMPLE
+    .\ModifyVIPBDisplayInfo.ps1 -SupportedBitness "64" -RelativePath "C:\repo" -VIPBPath "Tooling\deployment\NI Icon editor.vipb" -MinimumSupportedLVVersion 2023 -LabVIEWMinorRevision 3 -Major 1 -Minor 0 -Patch 0 -Build 2 -Commit "abcd123" -ReleaseNotesFile "Tooling\deployment\release_notes.md" -DisplayInformationJSON '{"Package Version":{"major":1,"minor":0,"patch":0,"build":2}}'
+#>
+param (
+    [string]$SupportedBitness,
+    [string]$RelativePath,
+    [string]$VIPBPath,
+
+    [int]$MinimumSupportedLVVersion,
+
+    [ValidateSet("0","3")]
+    [string]$LabVIEWMinorRevision = "0",
+
+    [int]$Major,
+    [int]$Minor,
+    [int]$Patch,
+    [int]$Build,
+    [string]$Commit,
+    [string]$ReleaseNotesFile,
+
+    [Parameter(Mandatory=$true)]
+    [string]$DisplayInformationJSON
+)
+
+# 1) Resolve paths
+try {
+    $ResolvedRelativePath = Resolve-Path -Path $RelativePath -ErrorAction Stop
+    $ResolvedVIPBPath = Join-Path -Path $ResolvedRelativePath -ChildPath $VIPBPath -ErrorAction Stop
+}
+catch {
+    $errorObject = [PSCustomObject]@{
+        error      = "Error resolving paths. Ensure RelativePath and VIPBPath are valid."
+        exception  = $_.Exception.Message
+        stackTrace = $_.Exception.StackTrace
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+
+# 2) Create release notes if needed
+if (-not (Test-Path $ReleaseNotesFile)) {
+    Write-Host "Release notes file '$ReleaseNotesFile' does not exist. Creating it..."
+    New-Item -ItemType File -Path $ReleaseNotesFile -Force | Out-Null
+}
+
+# 3) Calculate the LabVIEW version string
+$lvNumericMajor    = $MinimumSupportedLVVersion - 2000
+$lvNumericVersion  = "$($lvNumericMajor).$LabVIEWMinorRevision"
+if ($SupportedBitness -eq "64") {
+    $VIP_LVVersion_A = "$lvNumericVersion (64-bit)"
+}
+else {
+    $VIP_LVVersion_A = $lvNumericVersion
+}
+Write-Output "Modifying VI Package Information using LabVIEW $VIP_LVVersion_A..."
+
+# 4) Parse and update the DisplayInformationJSON
+try {
+    $jsonObj = $DisplayInformationJSON | ConvertFrom-Json
+}
+catch {
+    $errorObject = [PSCustomObject]@{
+        error      = "Failed to parse DisplayInformationJSON into valid JSON."
+        exception  = $_.Exception.Message
+        stackTrace = $_.Exception.StackTrace
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}
+
+# If "Package Version" doesn't exist, create it as a subobject
+if (-not $jsonObj.'Package Version') {
+    $jsonObj | Add-Member -MemberType NoteProperty -Name 'Package Version' -Value ([PSCustomObject]@{
+        major = $Major
+        minor = $Minor
+        patch = $Patch
+        build = $Build
+    })
+}
+else {
+    # "Package Version" exists, so just overwrite its fields
+    $jsonObj.'Package Version'.major = $Major
+    $jsonObj.'Package Version'.minor = $Minor
+    $jsonObj.'Package Version'.patch = $Patch
+    $jsonObj.'Package Version'.build = $Build
+}
+
+# Re-convert to a JSON string with a comfortable nesting depth
+$UpdatedDisplayInformationJSON = $jsonObj | ConvertTo-Json -Depth 5
+
+# 5) Prepare the g-cli command and arguments
+$cmd  = "g-cli"
+$args = @(
+    '--lv-ver', $MinimumSupportedLVVersion,
+    '--arch',   $SupportedBitness,
+    "$ResolvedRelativePath\Tooling\deployment\Modify_VIPB_Display_Information.vi",
+    '--',
+    $ResolvedVIPBPath,
+    $VIP_LVVersion_A,
+    $UpdatedDisplayInformationJSON
+)
+
+Write-Output "Executing: $cmd $($args -join ' ')"
+
+# 6) Execute the command safely
+try {
+    & $cmd @args
+    Write-Host "Successfully Modified VI package information: $ResolvedVIPBPath"
+}
+catch {
+    $errorObject = [PSCustomObject]@{
+        error      = "An error occurred while executing the build commands."
+        exception  = $_.Exception.Message
+        stackTrace = $_.Exception.StackTrace
+    }
+    $errorObject | ConvertTo-Json -Depth 10
+    exit 1
+}

--- a/.github/actions/modify-vipb-display-info/README.md
+++ b/.github/actions/modify-vipb-display-info/README.md
@@ -17,7 +17,6 @@ Execute **`ModifyVIPBDisplayInfo.ps1`** to merge metadata into a `.vipb` file be
 | `commit` | **Yes** | `abcdef` | Commit identifier. |
 | `release_notes_file` | **Yes** | `Tooling/deployment/release_notes.md` | Release notes file. |
 | `display_information_json` | **Yes** | `'{}'` | JSON for display information. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `ModifyVIPBDisplayInfo.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -34,7 +33,6 @@ Execute **`ModifyVIPBDisplayInfo.ps1`** to merge metadata into a `.vipb` file be
     commit: ${{ github.sha }}
     release_notes_file: Tooling/deployment/release_notes.md
     display_information_json: '{}'
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/modify-vipb-display-info/action.yml
+++ b/.github/actions/modify-vipb-display-info/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run ModifyVIPBDisplayInfo.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/ModifyVIPBDisplayInfo.ps1" \
+        & "${{ github.action_path }}/ModifyVIPBDisplayInfo.ps1" \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RelativePath "${{ inputs.relative_path }}" \
           -VIPBPath "${{ inputs.vipb_path }}" \
@@ -61,7 +61,4 @@ inputs:
     required: true
   display_information_json:
     description: 'DisplayInformation JSON string'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/prepare-labview-source/Prepare_LabVIEW_source.ps1
+++ b/.github/actions/prepare-labview-source/Prepare_LabVIEW_source.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Prepares LabVIEW source code for building.
+
+.DESCRIPTION
+    Executes the PrepareIESource.vi via g-cli to unzip required components and
+    update the LabVIEW configuration, ensuring the project is ready for
+    subsequent build steps.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used by g-cli.
+
+.PARAMETER SupportedBitness
+    Target bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root containing the project.
+
+.PARAMETER LabVIEW_Project
+    Name of the LabVIEW project (without extension).
+
+.PARAMETER Build_Spec
+    Name of the build specification to prepare.
+
+.EXAMPLE
+    .\Prepare_LabVIEW_source.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview icon editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library"
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$MinimumSupportedLVVersion,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("32", "64", IgnoreCase = $true)]
+    [string]$SupportedBitness,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path $_ })]
+    [string]$RelativePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$LabVIEW_Project,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Build_Spec
+)
+
+# Ensure paths with spaces are enclosed in double quotes
+$escapedRelativePath = "`"$RelativePath`""
+$escapedLabVIEWProjectPath = "`"$RelativePath\$LabVIEW_Project.lvproj`""
+$escapedBuildSpec = "`"$Build_Spec`""
+
+# Construct the command
+$script = @"
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness -v `"$RelativePath\Tooling\PrepareIESource.vi`" -- LabVIEW Localhost.LibraryPaths `"$RelativePath\$LabVIEW_Project.lvproj`" $Build_Spec
+"@
+
+Write-Output "Executing the following command:"
+Write-Output $script
+
+try {
+    # Execute the command and check for errors
+    Invoke-Expression $script
+
+    # Check the exit code
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Success: Process completed."
+        Write-Host "Unzipping vi.lib/LabVIEW Icon API from LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)."
+        Write-Host "Removing localhost.library path from ini file."
+    } else {
+        throw "Error: Command execution failed with exit code $LASTEXITCODE."
+    }
+} catch {
+    Write-Error "An error occurred during execution: $_"
+    Write-Error "Please check the parameters and ensure the command is valid."
+    exit 1
+}
+

--- a/.github/actions/prepare-labview-source/README.md
+++ b/.github/actions/prepare-labview-source/README.md
@@ -10,7 +10,6 @@ Runs **`Prepare_LabVIEW_source.ps1`** to unpack and configure project sources be
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
 | `labview_project` | **Yes** | `lv_icon_editor` | Project name (no extension). |
 | `build_spec` | **Yes** | `Editor Packed Library` | Build specification name. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `Prepare_LabVIEW_source.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -21,7 +20,6 @@ Runs **`Prepare_LabVIEW_source.ps1`** to unpack and configure project sources be
     relative_path: ${{ github.workspace }}
     labview_project: lv_icon_editor
     build_spec: "Editor Packed Library"
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/prepare-labview-source/action.yml
+++ b/.github/actions/prepare-labview-source/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run Prepare_LabVIEW_source.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/Prepare_LabVIEW_source.ps1" \
+        & "${{ github.action_path }}/Prepare_LabVIEW_source.ps1" \
           -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RelativePath "${{ inputs.relative_path }}" \
@@ -32,7 +32,4 @@ inputs:
     required: true
   build_spec:
     description: 'Build specification name'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/rename-file/README.md
+++ b/.github/actions/rename-file/README.md
@@ -7,7 +7,6 @@ Use **`Rename-file.ps1`** to rename a file within the repository.
 |------|----------|---------|-------------|
 | `current_filename` | **Yes** | `resource/plugins/lv_icon.lvlibp` | Existing file path. |
 | `new_filename` | **Yes** | `lv_icon_x64.lvlibp` | New file name or path. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `Rename-file.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -15,7 +14,6 @@ Use **`Rename-file.ps1`** to rename a file within the repository.
   with:
     current_filename: resource/plugins/lv_icon.lvlibp
     new_filename: lv_icon_x64.lvlibp
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/rename-file/Rename-file.ps1
+++ b/.github/actions/rename-file/Rename-file.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Renames a specified file.
+
+.DESCRIPTION
+    Checks whether the source file exists and, if so, renames it to the
+    provided target name.
+
+.PARAMETER CurrentFilename
+    Full path to the file to rename.
+
+.PARAMETER NewFilename
+    New name (including path) for the renamed file.
+
+.EXAMPLE
+    .\Rename-file.ps1 -CurrentFilename "C:\path\lv_icon.lvlibp" -NewFilename "lv_icon_x64.lvlibp"
+#>
+param(
+    [string]$CurrentFilename,
+    [string]$NewFilename
+)
+
+# Function to rename the file
+function Rename-File {
+    param(
+        [string]$CurrentFilename,
+        [string]$NewFilename
+    )
+    
+    # Check if the file exists
+    if (-Not (Test-Path -Path $CurrentFilename)) {
+        Write-Host "Error: File '$CurrentFilename' does not exist."
+        return
+    }
+
+    # Attempt to rename the file
+    try {
+        Rename-Item -Path $CurrentFilename -NewName $NewFilename
+        Write-Host "Rename the packed project library to '$NewFilename'." .ps1
+    } catch {
+        Write-Host "Error: Could not rename the file. $_"
+    }
+}
+
+# Call the function
+Rename-File -CurrentFilename $CurrentFilename -NewFilename $NewFilename
+

--- a/.github/actions/rename-file/action.yml
+++ b/.github/actions/rename-file/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run Rename-file.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/Rename-file.ps1" \
+        & "${{ github.action_path }}/Rename-file.ps1" \
           -CurrentFilename "${{ inputs.current_filename }}" \
           -NewFilename "${{ inputs.new_filename }}"
 inputs:
@@ -20,7 +20,4 @@ inputs:
     required: true
   new_filename:
     description: 'New file name or path'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/restore-setup-lv-source/README.md
+++ b/.github/actions/restore-setup-lv-source/README.md
@@ -10,7 +10,6 @@ Run **`RestoreSetupLVSource.ps1`** to restore packaged LabVIEW sources and remov
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
 | `labview_project` | **Yes** | `lv_icon_editor` | Project name (no extension). |
 | `build_spec` | **Yes** | `Editor Packed Library` | Build specification name. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `RestoreSetupLVSource.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -21,7 +20,6 @@ Run **`RestoreSetupLVSource.ps1`** to restore packaged LabVIEW sources and remov
     relative_path: ${{ github.workspace }}
     labview_project: lv_icon_editor
     build_spec: "Editor Packed Library"
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/restore-setup-lv-source/RestoreSetupLVSource.ps1
+++ b/.github/actions/restore-setup-lv-source/RestoreSetupLVSource.ps1
@@ -1,0 +1,54 @@
+<#
+.SYNOPSIS
+    Restores the LabVIEW source setup from a packaged state.
+
+.DESCRIPTION
+    Calls RestoreSetupLVSource.vi via g-cli to unzip the LabVIEW Icon API and
+    remove the Localhost.LibraryPaths token from the LabVIEW INI file.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW version used to run g-cli.
+
+.PARAMETER SupportedBitness
+    Bitness of the LabVIEW environment ("32" or "64").
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER LabVIEW_Project
+    Name of the LabVIEW project (without extension).
+
+.PARAMETER Build_Spec
+    Build specification name within the project.
+
+.EXAMPLE
+    .\RestoreSetupLVSource.ps1 -MinimumSupportedLVVersion "2021" -SupportedBitness "64" -RelativePath "C:\labview-icon-editor" -LabVIEW_Project "lv_icon_editor" -Build_Spec "Editor Packed Library"
+#>
+param(
+    [string]$MinimumSupportedLVVersion,
+    [string]$SupportedBitness,
+    [string]$RelativePath,
+    [string]$LabVIEW_Project,
+    [string]$Build_Spec
+)
+
+# Construct the command
+$script = @"
+g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness -v "$RelativePath\Tooling\RestoreSetupLVSource.vi" -- "$RelativePath\$LabVIEW_Project.lvproj" "$Build_Spec"
+"@
+
+Write-Output "Executing the following command:"
+Write-Output $script
+
+# Execute the command and check for errors
+try {
+    Invoke-Expression $script
+
+    # Check the exit code of the executed command
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Unzip vi.lib/LabVIEW Icon API from LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit) and remove localhost.library path from ini file"
+    }
+} catch {
+    Write-Host ""
+    exit 0
+}

--- a/.github/actions/restore-setup-lv-source/action.yml
+++ b/.github/actions/restore-setup-lv-source/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run RestoreSetupLVSource.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/RestoreSetupLVSource.ps1" \
+        & "${{ github.action_path }}/RestoreSetupLVSource.ps1" \
           -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
           -SupportedBitness ${{ inputs.supported_bitness }} \
           -RelativePath "${{ inputs.relative_path }}" \
@@ -32,7 +32,4 @@ inputs:
     required: true
   build_spec:
     description: 'Build specification name'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/revert-development-mode/README.md
+++ b/.github/actions/revert-development-mode/README.md
@@ -6,14 +6,12 @@ Invoke **`RevertDevelopmentMode.ps1`** to restore packaged sources after develop
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `RevertDevelopmentMode.ps1`. |
 
 ## Quick-start
 ```yaml
 - uses: ./.github/actions/revert-development-mode
   with:
     relative_path: ${{ github.workspace }}
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/revert-development-mode/RevertDevelopmentMode.ps1
+++ b/.github/actions/revert-development-mode/RevertDevelopmentMode.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+    Reverts the repository from development mode.
+
+.DESCRIPTION
+    Restores the packaged LabVIEW sources for both 32-bit and 64-bit
+    environments and closes any running LabVIEW instances.
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.EXAMPLE
+    .\RevertDevelopmentMode.ps1 -RelativePath "C:\labview-icon-editor"
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RelativePath
+)
+
+# Define LabVIEW project name
+$LabVIEW_Project = 'lv_icon_editor'
+
+# Determine the directory where this script is located
+$ScriptDirectory = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+Write-Host "Script Directory: $ScriptDirectory"
+
+# Helper function to execute scripts and stop on error
+function Execute-Script {
+    param(
+        [string]$ScriptCommand
+    )
+    Write-Host "Executing: $ScriptCommand"
+    try {
+        # Execute the command
+        Invoke-Expression $ScriptCommand -ErrorAction Stop
+
+        # Check for errors in the script execution
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Error occurred while executing: $ScriptCommand. Exit code: $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
+    } catch {
+        Write-Error "Error occurred while executing: $ScriptCommand. Exiting."
+        Write-Error $_.Exception.Message
+        exit 1
+    }
+}
+
+# Sequential script execution with error handling
+try {
+    # Build the script paths
+    $RestoreScript = Join-Path -Path $ScriptDirectory -ChildPath 'RestoreSetupLVSource.ps1'
+    $CloseScript = Join-Path -Path $ScriptDirectory -ChildPath 'Close_LabVIEW.ps1'
+
+    # Restore setup for LabVIEW 2021 (32-bit)
+    $Command1 = "& `"$RestoreScript`" -MinimumSupportedLVVersion 2021 -SupportedBitness 32 -RelativePath `"$RelativePath`" -LabVIEW_Project `"$LabVIEW_Project`" -Build_Spec `'Editor Packed Library`'"
+
+    Execute-Script $Command1
+
+    # Close LabVIEW 2021 (32-bit)
+    $Command2 = "& `"$CloseScript`" -MinimumSupportedLVVersion 2021 -SupportedBitness 32"
+
+    Execute-Script $Command2
+
+    # Restore setup for LabVIEW 2021 (64-bit)
+    $Command3 = "& `"$RestoreScript`" -MinimumSupportedLVVersion 2021 -SupportedBitness 64 -RelativePath `"$RelativePath`" -LabVIEW_Project `"$LabVIEW_Project`" -Build_Spec `'Editor Packed Library`'"
+
+    Execute-Script $Command3
+
+    # Close LabVIEW 2021 (64-bit)
+    $Command4 = "& `"$CloseScript`" -MinimumSupportedLVVersion 2021 -SupportedBitness 64"
+
+    Execute-Script $Command4
+
+} catch {
+    Write-Error "An unexpected error occurred during script execution: $($_.Exception.Message)"
+    exit 1
+}
+
+Write-Host "All scripts executed successfully." -ForegroundColor Green
+

--- a/.github/actions/revert-development-mode/action.yml
+++ b/.github/actions/revert-development-mode/action.yml
@@ -11,12 +11,9 @@ runs:
     - name: Run RevertDevelopmentMode.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/RevertDevelopmentMode.ps1" \
+        & "${{ github.action_path }}/RevertDevelopmentMode.ps1" \
           -RelativePath "${{ inputs.relative_path }}"
 inputs:
   relative_path:
     description: 'Workspace root path'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/run-unit-tests/README.md
+++ b/.github/actions/run-unit-tests/README.md
@@ -7,7 +7,6 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
 |------|----------|---------|-------------|
 | `minimum_supported_lv_version` | **Yes** | `2021` | LabVIEW major version. |
 | `supported_bitness` | **Yes** | `32` or `64` | Target LabVIEW bitness. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `RunUnitTests.ps1`. |
 
 ## Quick-start
 ```yaml
@@ -15,7 +14,6 @@ Invoke **`RunUnitTests.ps1`** to execute LabVIEW unit tests and output a result 
   with:
     minimum_supported_lv_version: 2024
     supported_bitness: 64
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/run-unit-tests/RunUnitTests.ps1
+++ b/.github/actions/run-unit-tests/RunUnitTests.ps1
@@ -1,0 +1,255 @@
+<#
+.SYNOPSIS
+    Run LabVIEW unit tests using g-cli and output a color-coded table of results.
+
+.DESCRIPTION
+    Demonstrates a Setup/MainSequence/Cleanup flow with:
+      - Table-based test results
+      - Color-coded pass/fail
+      - Non-zero exit if g-cli fails or if any test fails
+      - Automatic search for exactly one *.lvproj file by moving up the folder hierarchy 
+        until just before the drive root.
+
+.PARAMETER MinimumSupportedLVVersion
+    LabVIEW minimum supported version (e.g., "2021").
+
+.PARAMETER SupportedBitness
+    Bitness for LabVIEW (e.g., "64").
+
+.NOTES
+    PowerShell 7.5+ assumed for cross-platform support.
+    This script *requires* that g-cli and LabVIEW be compatible with the OS.
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]
+    $MinimumSupportedLVVersion,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("32","64")]
+    [string]
+    $SupportedBitness
+)
+
+# --------------------------------------------------------------------
+# 1) Locate exactly one .lvproj file by searching upward from $PSScriptRoot
+# --------------------------------------------------------------------
+Write-Host "Starting directory for .lvproj search: $PSScriptRoot"
+
+function Get-SingleLvproj {
+    param(
+        [string] $StartFolder
+    )
+
+    $currentDir = $StartFolder
+
+    while ($true) {
+        Write-Host "Searching '$currentDir' for *.lvproj files..."
+        $lvprojFiles = Get-ChildItem -Path $currentDir -Filter '*.lvproj' -File -ErrorAction SilentlyContinue
+
+        if ($lvprojFiles.Count -eq 1) {
+            # Found exactly one .lvproj
+            return $lvprojFiles[0].FullName
+        }
+        elseif ($lvprojFiles.Count -gt 1) {
+            # Found multiple .lvproj files
+            Write-Error "Error: Multiple .lvproj files found in '$currentDir'. Please ensure only one .lvproj is present."
+            $lvprojFiles | ForEach-Object { Write-Host " - $_.FullName" }
+            return $null
+        }
+        
+        # If none found, move one level up
+        $parentDir = Split-Path -Path $currentDir -Parent
+        
+        # If we've reached or are about to reach the drive root, stop searching
+        $driveRoot = [System.IO.Path]::GetPathRoot($currentDir)
+        if ($parentDir -eq $currentDir -or $parentDir -eq $driveRoot) {
+            Write-Error "Error: Reached the level before root without finding exactly one .lvproj."
+            return $null
+        }
+
+        $currentDir = $parentDir
+    }
+}
+
+$AbsoluteProjectPath = Get-SingleLvproj -StartFolder $PSScriptRoot
+
+if (-not $AbsoluteProjectPath) {
+    # We failed to find exactly one .lvproj in any ancestor up to the level before root
+    exit 3
+}
+Write-Host "Using LabVIEW project file: $AbsoluteProjectPath"
+
+# Script-level variables to track exit states
+$Script:OriginalExitCode = 0
+$Script:TestsHadFailures = $false
+
+# Path to UnitTestReport.xml in the same directory as this script
+$ReportPath = Join-Path -Path $PSScriptRoot -ChildPath "UnitTestReport.xml"
+
+# --------------------------  SETUP  --------------------------
+function Setup {
+    Write-Host "=== Setup ==="
+    if (Test-Path $ReportPath) {
+        try {
+            Remove-Item $ReportPath -Force -ErrorAction Stop
+            Write-Host "Deleted existing UnitTestReport.xml."
+        }
+        catch {
+            Write-Warning "Could not remove UnitTestReport.xml: $($_.Exception.Message)"
+        }
+    }
+    else {
+        Write-Host "No existing UnitTestReport.xml found. Continuing..."
+    }
+}
+
+# ------------------------  MAIN SEQUENCE  ----------------------
+function MainSequence {
+    Write-Host "`n=== MainSequence ==="
+    Write-Host "Running unit tests for LabVIEW $MinimumSupportedLVVersion ($SupportedBitness-bit)"
+    Write-Host "Project Path: $AbsoluteProjectPath"
+    Write-Host "Report will be saved at: $ReportPath"
+
+    Write-Host "`nExecuting g-cli command..."
+    & g-cli --lv-ver $MinimumSupportedLVVersion --arch $SupportedBitness lunit -- -r "$ReportPath" "$AbsoluteProjectPath"
+
+    $script:OriginalExitCode = $LASTEXITCODE
+    if ($script:OriginalExitCode -ne 0) {
+        Write-Error "g-cli test execution failed (exit code $script:OriginalExitCode)."
+    }
+
+    # If g-cli failed and no report was produced, we can't parse anything
+    if ($script:OriginalExitCode -ne 0 -and -not (Test-Path $ReportPath)) {
+        $script:TestsHadFailures = $true
+        Write-Warning "No test report found, and g-cli returned an error."
+        return
+    }
+
+    # Parse UnitTestReport.xml if it exists
+    if (Test-Path $ReportPath) {
+        try {
+            [xml]$xmlDoc = Get-Content $ReportPath -ErrorAction Stop
+        }
+        catch {
+            Write-Error "UnitTestReport.xml is invalid or malformed: $($_.Exception.Message)"
+            $script:TestsHadFailures = $true
+            return
+        }
+    }
+    else {
+        Write-Error "UnitTestReport.xml not found; cannot parse results."
+        $script:TestsHadFailures = $true
+        return
+    }
+
+    # Retrieve all <testcase> nodes
+    $testCases = $xmlDoc.SelectNodes("//testcase")
+    if (!$testCases -or $testCases.Count -eq 0) {
+        Write-Error "No <testcase> entries found in UnitTestReport.xml."
+        $script:TestsHadFailures = $true
+        return
+    }
+
+    # Prepare for tabular output
+    $col1 = "TestCaseName"; $col2 = "ClassName"; $col3 = "Status"; $col4 = "Time(s)"; $col5 = "Assertions"
+    $maxName   = $col1.Length
+    $maxClass  = $col2.Length
+    $maxStatus = $col3.Length
+    $maxTime   = $col4.Length
+    $maxAssert = $col5.Length
+
+    $results = @()
+    foreach ($case in $testCases) {
+        $name       = $case.GetAttribute("name")
+        $className  = $case.GetAttribute("classname")
+        $status     = $case.GetAttribute("status")
+        $time       = $case.GetAttribute("time")
+        $assertions = $case.GetAttribute("assertions")
+
+        # If status is empty, treat as "Skipped" so it doesn't cause a false fail
+        if ([string]::IsNullOrWhiteSpace($status)) {
+            $status = "Skipped"
+        }
+
+        # Update max lengths for formatting
+        if ($name.Length       -gt $maxName)   { $maxName   = $name.Length }
+        if ($className.Length  -gt $maxClass)  { $maxClass  = $className.Length }
+        if ($status.Length     -gt $maxStatus) { $maxStatus = $status.Length }
+        if ($time.Length       -gt $maxTime)   { $maxTime   = $time.Length }
+        if ($assertions.Length -gt $maxAssert) { $maxAssert = $assertions.Length }
+
+        # Store data
+        $results += [PSCustomObject]@{
+            TestCaseName = $name
+            ClassName    = $className
+            Status       = $status
+            Time         = $time
+            Assertions   = $assertions
+        }
+
+        # Mark any test that isn't Passed or Skipped as a failure
+        if ($status -notmatch "^Passed$" -and $status -notmatch "^Skipped$") {
+            $script:TestsHadFailures = $true
+        }
+    }
+
+    # Print table header
+    $header = ($col1.PadRight($maxName) + "  " +
+               $col2.PadRight($maxClass) + "  " +
+               $col3.PadRight($maxStatus) + "  " +
+               $col4.PadRight($maxTime) + "  " +
+               $col5.PadRight($maxAssert))
+    Write-Host $header
+
+    # Output test results in color
+    foreach ($res in $results) {
+        $line = ($res.TestCaseName.PadRight($maxName) + "  " +
+                 $res.ClassName.PadRight($maxClass)   + "  " +
+                 $res.Status.PadRight($maxStatus)     + "  " +
+                 $res.Time.PadRight($maxTime)         + "  " +
+                 $res.Assertions.PadRight($maxAssert))
+
+        if ($res.Status -eq "Passed") {
+            Write-Host $line -ForegroundColor Green
+        }
+        elseif ($res.Status -eq "Skipped") {
+            Write-Host $line -ForegroundColor Yellow
+        }
+        else {
+            Write-Host $line -ForegroundColor Red
+        }
+    }
+}
+
+# --------------------------  CLEANUP  --------------------------
+function Cleanup {
+    Write-Host "`n=== Cleanup ==="
+    # If everything passed (and g-cli was OK), delete the report
+    if (($script:OriginalExitCode -eq 0) -and (-not $script:TestsHadFailures)) {
+        try {
+            Remove-Item $ReportPath -Force -ErrorAction Stop
+            Write-Host "`nAll tests passed. Deleted UnitTestReport.xml."
+        }
+        catch {
+            Write-Warning "Failed to delete $($ReportPath): $($_.Exception.Message)"
+        }
+    }
+}
+
+# -------------------  EXECUTION FLOW  -------------------
+Setup
+MainSequence
+#Cleanup
+
+# -------------------  FINAL EXIT CODE  ------------------
+if ($Script:OriginalExitCode -ne 0) {
+    exit $Script:OriginalExitCode
+}
+elseif ($Script:TestsHadFailures) {
+    exit 2
+}
+else {
+    exit 0
+}

--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -11,7 +11,7 @@ runs:
     - name: Run RunUnitTests.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/RunUnitTests.ps1" \
+        & "${{ github.action_path }}/RunUnitTests.ps1" \
           -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
           -SupportedBitness ${{ inputs.supported_bitness }}
 inputs:
@@ -20,7 +20,4 @@ inputs:
     required: true
   supported_bitness:
     description: '32 or 64'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/set-development-mode/README.md
+++ b/.github/actions/set-development-mode/README.md
@@ -6,14 +6,12 @@ Execute **`Set_Development_Mode.ps1`** to prepare the repository for active deve
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `Set_Development_Mode.ps1`. |
 
 ## Quick-start
 ```yaml
 - uses: ./.github/actions/set-development-mode
   with:
     relative_path: ${{ github.workspace }}
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/set-development-mode/Set_Development_Mode.ps1
+++ b/.github/actions/set-development-mode/Set_Development_Mode.ps1
@@ -1,0 +1,49 @@
+<#
+.SYNOPSIS
+    Configures the repository for development mode.
+
+.DESCRIPTION
+    Removes existing packed libraries, adds INI tokens, prepares LabVIEW
+    sources for both 32-bit and 64-bit environments, and closes LabVIEW.
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.EXAMPLE
+    .\Set_Development_Mode.ps1 -RelativePath "C:\labview-icon-editor"
+#>
+
+param(
+    [string]$RelativePath
+)
+
+# Helper function to execute scripts and stop on error
+function Execute-Script {
+    param(
+        [string]$ScriptCommand
+    )
+    Write-Host "Executing: $ScriptCommand"
+    try {
+        Invoke-Expression $ScriptCommand -ErrorAction Stop
+    } catch {
+        Write-Error "Error occurred while executing: $ScriptCommand. Exiting."
+        exit 1
+    }
+}
+# Sequential script execution with error handling
+try {
+	Execute-Script "Get-ChildItem -Path '$RelativePath\resource\plugins' -Filter '*.lvlibp' | Remove-Item -Force" 
+    Execute-Script ".\AddTokenToLabVIEW.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 32 -RelativePath '$RelativePath'"
+    Execute-Script ".\Prepare_LabVIEW_source.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 32 -RelativePath '$RelativePath' -LabVIEW_Project 'lv_icon_editor' -Build_Spec 'Editor Packed Library'" 
+    Execute-Script ".\Close_LabVIEW.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 32" 
+	Execute-Script ".\AddTokenToLabVIEW.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 64 -RelativePath '$RelativePath'" 
+    Execute-Script ".\Prepare_LabVIEW_source.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 64 -RelativePath '$RelativePath' -LabVIEW_Project 'lv_icon_editor' -Build_Spec 'Editor Packed Library'" 
+    Execute-Script ".\Close_LabVIEW.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 64" 
+
+} catch {
+    Write-Error "An unexpected error occurred during script execution: $($_.Exception.Message)"
+    exit 1
+}
+
+Write-Host "All scripts executed successfully."
+

--- a/.github/actions/set-development-mode/action.yml
+++ b/.github/actions/set-development-mode/action.yml
@@ -11,12 +11,9 @@ runs:
     - name: Run Set_Development_Mode.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/Set_Development_Mode.ps1" \
+        & "${{ github.action_path }}/Set_Development_Mode.ps1" \
           -RelativePath "${{ inputs.relative_path }}"
 inputs:
   relative_path:
     description: 'Workspace root path'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/unit-tests/README.md
+++ b/.github/actions/unit-tests/README.md
@@ -6,14 +6,12 @@ Use **`unit_tests.ps1`** to orchestrate setup and LabVIEW unit testing for both 
 | Name | Required | Example | Description |
 |------|----------|---------|-------------|
 | `relative_path` | **Yes** | `${{ github.workspace }}` | Repository root path. |
-| `scripts_folder` | **Yes** | `pipeline/scripts` | Folder containing `unit_tests.ps1`. |
 
 ## Quick-start
 ```yaml
 - uses: ./.github/actions/unit-tests
   with:
     relative_path: ${{ github.workspace }}
-    scripts_folder: pipeline/scripts
 ```
 
 ## License

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -11,13 +11,10 @@ runs:
     - name: Run unit_tests.ps1
       shell: pwsh
       run: |
-        & "${{ inputs.scripts_folder }}/unit_tests.ps1" \
+        & "${{ github.action_path }}/unit_tests.ps1" \
           -RelativePath "${{ inputs.relative_path }}" \
-          -AbsolutePathScripts "${{ inputs.relative_path }}/${{ inputs.scripts_folder }}"
+          -AbsolutePathScripts "${{ github.action_path }}"
 inputs:
   relative_path:
     description: 'Workspace root path'
-    required: true
-  scripts_folder:
-    description: 'Path to your pipeline/scripts folder'
     required: true

--- a/.github/actions/unit-tests/unit_tests.ps1
+++ b/.github/actions/unit-tests/unit_tests.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Runs a suite of PowerShell test scripts for the repository.
+
+.DESCRIPTION
+    Validates that required paths exist and sequentially executes supporting
+    scripts to prepare and test the LabVIEW icon editor project.
+
+.PARAMETER RelativePath
+    Path to the repository root.
+
+.PARAMETER AbsolutePathScripts
+    Absolute path to the pipeline scripts directory.
+
+.EXAMPLE
+    .\unit_tests.ps1 -RelativePath "C:\labview-icon-editor" -AbsolutePathScripts "C:\labview-icon-editor\pipeline\scripts"
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$RelativePath,
+    
+    [Parameter(Mandatory = $true)]
+    [string]$AbsolutePathScripts
+)
+
+# Helper function to check for file or directory existence
+function Assert-PathExists {
+    param(
+        [string]$Path,
+        [string]$Description
+    )
+    if (-Not (Test-Path -Path $Path)) {
+        Write-Host "The $Description does not exist: $Path" -ForegroundColor Red
+        exit 1
+    }
+}
+
+# Helper function to execute scripts sequentially
+function Execute-Script {
+    param(
+        [string]$ScriptPath,
+        [string]$Arguments
+    )
+    Write-Host "Executing: $ScriptPath $Arguments" -ForegroundColor Cyan
+    try {
+        # Build and execute the command
+        $command = "& `"$ScriptPath`" $Arguments"
+        Invoke-Expression $command
+
+        # Check for errors in the script execution
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Error occurred while executing: $ScriptPath with arguments: $Arguments. Exit code: $LASTEXITCODE" -ForegroundColor Red
+            exit $LASTEXITCODE
+        }
+    } catch {
+        Write-Host "Error occurred while executing: $ScriptPath with arguments: $Arguments. Exiting." -ForegroundColor Red
+        exit 1
+    }
+}
+
+# Main script logic
+try {
+    # Validate required paths
+    Assert-PathExists $RelativePath "RelativePath"
+    Assert-PathExists "$RelativePath\resource\plugins" "Plugins folder"
+    Assert-PathExists $AbsolutePathScripts "Scripts folder"
+
+    # Clean up .lvlibp files in the plugins folder
+    Write-Host "Cleaning up old .lvlibp files in plugins folder..." -ForegroundColor Yellow
+    $PluginFiles = Get-ChildItem -Path "$RelativePath\resource\plugins" -Filter '*.lvlibp' -ErrorAction SilentlyContinue
+    if ($PluginFiles) {
+        $PluginFiles | Remove-Item -Force
+        Write-Host "Deleted .lvlibp files from plugins folder." -ForegroundColor Green
+    } else {
+        Write-Host "No .lvlibp files found to delete." -ForegroundColor Cyan
+    }
+    
+    # Run Unit Tests
+    Execute-Script "$($AbsolutePathScripts)\RunUnitTests.ps1" `
+        "-MinimumSupportedLVVersion 2021 -SupportedBitness 32 -RelativePath `"$RelativePath`""
+
+    # Close LabVIEW
+    Execute-Script "$($AbsolutePathScripts)\Close_LabVIEW.ps1" `
+        "-MinimumSupportedLVVersion 2021 -SupportedBitness 32"
+
+    # Run Unit Tests
+    Execute-Script "$($AbsolutePathScripts)\RunUnitTests.ps1" `
+        "-MinimumSupportedLVVersion 2021 -SupportedBitness 64 -RelativePath `"$RelativePath`""
+
+	# Close LabVIEW
+    Execute-Script "$($AbsolutePathScripts)\Close_LabVIEW.ps1" `
+        "-MinimumSupportedLVVersion 2021 -SupportedBitness 64"
+		
+    Write-Host "All scripts executed successfully!" -ForegroundColor Green
+} catch {
+    Write-Host "An unexpected error occurred during script execution: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}
+


### PR DESCRIPTION
## Summary
- embed pipeline PowerShell scripts directly in their corresponding action folders
- invoke scripts via `github.action_path` and remove `scripts_folder` input
- update action documentation to match

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891491f64cc8329b340ede5a45e5ed8