### PR TITLE
fix run-unit-tests action parameters

### DIFF
--- a/.github/actions/run-unit-tests/action.yml
+++ b/.github/actions/run-unit-tests/action.yml
@@ -11,8 +11,8 @@ runs:
     - name: Run RunUnitTests.ps1
       shell: pwsh
       run: |
-        & "${{ github.action_path }}/RunUnitTests.ps1" \
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
+        & "${{ github.action_path }}/RunUnitTests.ps1" `
+          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
           -SupportedBitness ${{ inputs.supported_bitness }}
 inputs:
   minimum_supported_lv_version:


### PR DESCRIPTION
## Summary
- fix run-unit-tests composite action to pass minimum version and bitness parameters correctly

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689152b91bb48329977c14565f21ea7c