### PR TITLE
Fix composite build action parameters

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,16 +11,16 @@ runs:
     - name: Run Build.ps1
       shell: pwsh
       run: |
-        & "${{ github.action_path }}/Build.ps1" \
-          -RelativePath "${{ inputs.relative_path }}" \
-          -AbsolutePathScripts "${{ github.action_path }}" \
-          -Major ${{ inputs.major }} \
-          -Minor ${{ inputs.minor }} \
-          -Patch ${{ inputs.patch }} \
-          -Build ${{ inputs.build }} \
-          -Commit "${{ inputs.commit }}" \
-          -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} \
-          -CompanyName "${{ inputs.company_name }}" \
+        & "${{ github.action_path }}/Build.ps1" `
+          -RelativePath "${{ inputs.relative_path }}" `
+          -AbsolutePathScripts "${{ inputs.relative_path }}/pipeline/scripts" `
+          -Major ${{ inputs.major }} `
+          -Minor ${{ inputs.minor }} `
+          -Patch ${{ inputs.patch }} `
+          -Build ${{ inputs.build }} `
+          -Commit "${{ inputs.commit }}" `
+          -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} `
+          -CompanyName "${{ inputs.company_name }}" `
           -AuthorName "${{ inputs.author_name }}"
 inputs:
   relative_path:


### PR DESCRIPTION
## Summary
- fix composite `build` action to pass required parameters to `Build.ps1`
- reference pipeline scripts and use PowerShell line continuations

## Testing
- `python - <<'PY'
import yaml,sys
with open('.github/actions/build/action.yml') as f:
    yaml.safe_load(f)
print('YAML ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_689155f54a5c832985f73ae55f0164b7