### PR TITLE
feat: add compute version composite action

### DIFF
--- a/.github/actions/compute-version/README.md
+++ b/.github/actions/compute-version/README.md
@@ -1,0 +1,21 @@
+# Compute Version
+
+This composite action determines the semantic version for the build based on commit history, branch naming conventions and pull request labels.
+
+## Inputs
+- `github_token`: GitHub token with repository access.
+
+## Outputs
+- `VERSION`: Full version string (e.g. `v1.2.3-build4`).
+- `MAJOR`, `MINOR`, `PATCH`: Numeric version components.
+- `BUILD`: Commit-based build number.
+- `IS_PRERELEASE`: `true` when branch naming implies prerelease.
+
+## Example
+```yaml
+- id: version
+  uses: ./.github/actions/compute-version
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+- run: echo "Version is ${{ steps.version.outputs.VERSION }}"
+```

--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -1,0 +1,84 @@
+name: "Compute Version"
+description: "Determines semantic version components and full version string based on branch, labels and commit count."
+inputs:
+  github_token:
+    description: "GitHub token with repository access"
+    required: true
+outputs:
+  VERSION:
+    description: "Full version string"
+    value: ${{ steps.next_version.outputs.VERSION }}
+  MAJOR:
+    description: "Major version"
+    value: ${{ steps.next_version.outputs.MAJOR }}
+  MINOR:
+    description: "Minor version"
+    value: ${{ steps.next_version.outputs.MINOR }}
+  PATCH:
+    description: "Patch version"
+    value: ${{ steps.next_version.outputs.PATCH }}
+  BUILD:
+    description: "Commit-based build number"
+    value: ${{ steps.inc_build.outputs.new_build_number }}
+  IS_PRERELEASE:
+    description: "Whether the version is a prerelease"
+    value: ${{ steps.next_version.outputs.IS_PRERELEASE }}
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Determine bump type
+      id: bump_type
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          let bump = 'none';
+          if (context.event_name === 'pull_request') {
+            const labels = context.payload.pull_request.labels.map(l => l.name.toLowerCase());
+            if (labels.includes('major')) bump = 'major';
+            else if (labels.includes('minor')) bump = 'minor';
+            else if (labels.includes('patch')) bump = 'patch';
+          }
+          core.setOutput('bump_type', bump);
+
+    - name: Determine build number
+      id: inc_build
+      shell: pwsh
+      run: |
+        git fetch --unshallow 2>$null || Write-Host "Already a full clone."
+        $count = git rev-list --count HEAD
+        Write-Host "Commit-based build number => $count"
+        "new_build_number=$count" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+
+    - name: Compute version string
+      id: next_version
+      shell: pwsh
+      env:
+        BUMP_TYPE:    ${{ steps.bump_type.outputs.bump_type }}
+        BUILD_NUMBER: ${{ steps.inc_build.outputs.new_build_number }}
+      run: |
+        $latest = (git describe --tags --abbrev=0 2>$null).TrimStart('v') -replace '-build.*'
+        if (-not $latest) { $maj=0; $min=0; $pat=0 } else { $maj,$min,$pat = $latest.Split('.') }
+        switch ($env:BUMP_TYPE) {
+          'major' { $maj++; $min=0; $pat=0 }
+          'minor' { $min++; $pat=0 }
+          'patch' { $pat++ }
+        }
+        $branch = $Env:GITHUB_REF -replace '^refs/heads/',''
+        $suffix = ''
+        if ($branch -like 'release-alpha/*') { $suffix = "alpha.$($Env:BUILD_NUMBER)" }
+        elseif ($branch -like 'release-beta/*')  { $suffix = "beta.$($Env:BUILD_NUMBER)" }
+        elseif ($branch -like 'release-rc/*')    { $suffix = "rc.$($Env:BUILD_NUMBER)" }
+        $version = if ($suffix) { "v$maj.$min.$pat-$suffix-build$($Env:BUILD_NUMBER)" } else { "v$maj.$min.$pat-build$($Env:BUILD_NUMBER)" }
+        $isPre  = if ($suffix) { 'true' } else { 'false' }
+        Write-Host "Computed version => $version"
+        "VERSION=$version"      | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "MAJOR=$maj"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "MINOR=$min"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "PATCH=$pat"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+        "IS_PRERELEASE=$isPre"  | Out-File -FilePath $Env:GITHUB_OUTPUT -Append

--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -48,6 +48,22 @@ jobs:
           relative_path:                ${{ github.workspace }}
           vipc_path:                    "Tooling/deployment/runner_dependencies.vipc"
 
+  version:
+    name: Compute Version
+    runs-on: self-hosted-windows-lv
+    outputs:
+      VERSION:       ${{ steps.compute.outputs.VERSION }}
+      MAJOR:         ${{ steps.compute.outputs.MAJOR }}
+      MINOR:         ${{ steps.compute.outputs.MINOR }}
+      PATCH:         ${{ steps.compute.outputs.PATCH }}
+      BUILD:         ${{ steps.compute.outputs.BUILD }}
+      IS_PRERELEASE: ${{ steps.compute.outputs.IS_PRERELEASE }}
+    steps:
+      - id: compute
+        uses: ./.github/actions/compute-version
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
   missing-in-project-check:
     name: Test Missing-In-Project Action on Windows
     needs: apply-deps
@@ -82,16 +98,16 @@ jobs:
 
   build-package:
     name: Build VI Package
-    needs: [test, apply-deps]
+    needs: [test, apply-deps, version]
     runs-on: self-hosted-windows-lv
     steps:
       - uses: ./.github/actions/build
         with:
           relative_path: ${{ github.workspace }}
-          major:         0
-          minor:         0
-          patch:         0
-          build:         1
+          major:         ${{ needs.version.outputs.MAJOR }}
+          minor:         ${{ needs.version.outputs.MINOR }}
+          patch:         ${{ needs.version.outputs.PATCH }}
+          build:         ${{ needs.version.outputs.BUILD }}
           commit:        ${{ github.sha }}
           company_name:  ${{ github.repository_owner }}
           author_name:   ${{ github.event.repository.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,64 +46,17 @@ jobs:
     needs: prepare
     runs-on: self-hosted-windows-lv
     outputs:
-      VERSION:       ${{ steps.next_version.outputs.VERSION }}
-      MAJOR:         ${{ steps.next_version.outputs.MAJOR }}
-      MINOR:         ${{ steps.next_version.outputs.MINOR }}
-      PATCH:         ${{ steps.next_version.outputs.PATCH }}
-      BUILD:         ${{ steps.inc_build.outputs.new_build_number }}
-      IS_PRERELEASE: ${{ steps.next_version.outputs.IS_PRERELEASE }}
+      VERSION:       ${{ steps.compute.outputs.VERSION }}
+      MAJOR:         ${{ steps.compute.outputs.MAJOR }}
+      MINOR:         ${{ steps.compute.outputs.MINOR }}
+      PATCH:         ${{ steps.compute.outputs.PATCH }}
+      BUILD:         ${{ steps.compute.outputs.BUILD }}
+      IS_PRERELEASE: ${{ steps.compute.outputs.IS_PRERELEASE }}
     steps:
-      - name: Determine bump type
-        id: bump_type
-        uses: actions/github-script@v6
+      - id: compute
+        uses: ./.github/actions/compute-version
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            let bump = 'none';
-            if (context.event_name === 'pull_request') {
-              const labels = context.payload.pull_request.labels.map(l => l.name.toLowerCase());
-              if (labels.includes('major')) bump = 'major';
-              else if (labels.includes('minor')) bump = 'minor';
-              else if (labels.includes('patch')) bump = 'patch';
-            }
-            core.setOutput('bump_type', bump);
-
-      - name: Determine build number
-        id: inc_build
-        shell: pwsh
-        run: |
-          git fetch --unshallow 2>$null || Write-Host "Already a full clone."
-          $count = git rev-list --count HEAD
-          Write-Host "Commit-based build number => $count"
-          "new_build_number=$count" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-
-      - name: Compute version string
-        id: next_version
-        shell: pwsh
-        env:
-          BUMP_TYPE:    ${{ steps.bump_type.outputs.bump_type }}
-          BUILD_NUMBER: ${{ steps.inc_build.outputs.new_build_number }}
-        run: |
-          $latest = (git describe --tags --abbrev=0 2>$null).TrimStart('v') -replace '-build.*'
-          if (-not $latest) { $maj=0; $min=0; $pat=0 } else { $maj,$min,$pat = $latest.Split('.') }
-          switch ($env:BUMP_TYPE) {
-            'major' { $maj++; $min=0; $pat=0 }
-            'minor' { $min++; $pat=0 }
-            'patch' { $pat++ }
-          }
-          $branch = $Env:GITHUB_REF -replace '^refs/heads/',''
-          $suffix = ''
-          if ($branch -like 'release-alpha/*') { $suffix = "alpha.$($Env:BUILD_NUMBER)" }
-          elseif ($branch -like 'release-beta/*')  { $suffix = "beta.$($Env:BUILD_NUMBER)" }
-          elseif ($branch -like 'release-rc/*')    { $suffix = "rc.$($Env:BUILD_NUMBER)" }
-          $version = if ($suffix) { "v$maj.$min.$pat-$suffix-build$($Env:BUILD_NUMBER)" } else { "v$maj.$min.$pat-build$($Env:BUILD_NUMBER)" }
-          $isPre  = if ($suffix) { 'true' } else { 'false' }
-          Write-Host "Computed version => $version"
-          "VERSION=$version"      | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "MAJOR=$maj"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "MINOR=$min"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "PATCH=$pat"            | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
-          "IS_PRERELEASE=$isPre"  | Out-File -FilePath $Env:GITHUB_OUTPUT -Append
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   apply-deps:
     name: Apply VIPC Dependencies


### PR DESCRIPTION
## Summary
- add reusable compute-version composite GitHub action
- update main CI workflow to use new action
- compute version in composite workflow and feed build job

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891582ddcf88329ab4e31988fd30889