### PR TITLE
chore: update artifact actions to v4

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -119,7 +119,7 @@ jobs:
         with:
           current_filename: ${{ github.workspace }}/resource/plugins/lv_icon.lvlibp
           new_filename: ${{ github.workspace }}/resource/plugins/lv_icon_x86.lvlibp
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lv_icon_x86.lvlibp
           path: resource/plugins/lv_icon_x86.lvlibp
@@ -147,7 +147,7 @@ jobs:
         with:
           current_filename: ${{ github.workspace }}/resource/plugins/lv_icon.lvlibp
           new_filename: ${{ github.workspace }}/resource/plugins/lv_icon_x64.lvlibp
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: lv_icon_x64.lvlibp
           path: resource/plugins/lv_icon_x64.lvlibp
@@ -160,11 +160,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: lv_icon_x86.lvlibp
           path: resource/plugins
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: lv_icon_x64.lvlibp
           path: resource/plugins


### PR DESCRIPTION
## Summary
- use actions/upload-artifact v4 for packed library builds
- use actions/download-artifact v4 when assembling VI package

## Testing
- `yamllint .github/workflows/ci-composite.yml` *(fails: line-length, colons, commas, truthy)*

------
https://chatgpt.com/codex/tasks/task_e_689160a88c48832981916d4d01ca145d