### PR TITLE
feat: add release notes generator action

### DIFF
--- a/.github/actions/generate-release-notes/GenerateReleaseNotes.ps1
+++ b/.github/actions/generate-release-notes/GenerateReleaseNotes.ps1
@@ -1,0 +1,26 @@
+param(
+    [string]$OutputPath = "Tooling/deployment/release_notes.md"
+)
+
+# Ensure git history is available
+git fetch --tags --unshallow 2>$null | Out-Null
+
+$latestTag = git describe --tags --abbrev=0 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($latestTag)) {
+    $log = git log --pretty=format:'- %s (%h)' --no-merges
+} else {
+    $log = git log "$latestTag..HEAD" --pretty=format:'- %s (%h)' --no-merges
+}
+if (-not $log) {
+    $log = "- Initial release"
+} else {
+    $log = $log -join "`n"
+}
+$notes = "# Release Notes`n`n$log`n"
+$fullPath = Join-Path (Get-Location) $OutputPath
+$directory = Split-Path $fullPath
+if (-not (Test-Path $directory)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+}
+Set-Content -Path $fullPath -Value $notes
+Write-Host "Release notes written to $fullPath"

--- a/.github/actions/generate-release-notes/README.md
+++ b/.github/actions/generate-release-notes/README.md
@@ -1,0 +1,17 @@
+# Generate Release Notes
+
+This composite action creates a Markdown file summarizing commits since the last tag.
+The resulting file can be injected into the VI Package build process.
+
+## Inputs
+
+- `output_path` (optional): Path for the generated release notes file relative to the repository root. Defaults to `Tooling/deployment/release_notes.md`.
+
+## Example Usage
+
+```yaml
+- name: Generate release notes
+  uses: ./.github/actions/generate-release-notes
+  with:
+    output_path: Tooling/deployment/release_notes.md
+```

--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -1,0 +1,19 @@
+name: "Generate Release Notes"
+description: "Creates a markdown release notes file from git history."
+inputs:
+  output_path:
+    description: 'Path for the release notes file (relative to workspace).'
+    required: false
+    default: 'Tooling/deployment/release_notes.md'
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        clean: false
+    - name: Generate release notes
+      shell: pwsh
+      run: |
+        & "${{ github.action_path }}/GenerateReleaseNotes.ps1" -OutputPath "${{ inputs.output_path }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,11 @@ jobs:
         shell: pwsh
         run: git config --global --add safe.directory "$Env:GITHUB_WORKSPACE"
 
+      - name: Generate release notes
+        uses: ./.github/actions/generate-release-notes
+        with:
+          output_path: Tooling/deployment/release_notes.md
+
       - name: Possibly disable GPG signing on forks
         if: ${{ env.DISABLE_GPG_ON_FORKS == 'true' }}
         id: disable_signing


### PR DESCRIPTION
## Summary
- add composite action to create release_notes.md from git history
- use release notes generator in CI before building VI package

## Testing
- `pwsh .github/actions/generate-release-notes/GenerateReleaseNotes.ps1 -OutputPath Tooling/deployment/test_release_notes.md`

------
https://chatgpt.com/codex/tasks/task_e_68916277b7448329b0e1d594369e3bf4