### PR TITLE
Fix PowerShell invocation in build-lvlibp action

### DIFF
--- a/.github/actions/build-lvlibp/action.yml
+++ b/.github/actions/build-lvlibp/action.yml
@@ -11,14 +11,14 @@ runs:
     - name: Run Build_lvlibp.ps1
       shell: pwsh
       run: |
-        & "${{ github.action_path }}/Build_lvlibp.ps1" \
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
-          -SupportedBitness ${{ inputs.supported_bitness }} \
-          -RelativePath "${{ inputs.relative_path }}" \
-          -Major ${{ inputs.major }} \
-          -Minor ${{ inputs.minor }} \
-          -Patch ${{ inputs.patch }} \
-          -Build ${{ inputs.build }} \
+        & "${{ github.action_path }}/Build_lvlibp.ps1" `
+          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -SupportedBitness ${{ inputs.supported_bitness }} `
+          -RelativePath "${{ inputs.relative_path }}" `
+          -Major ${{ inputs.major }} `
+          -Minor ${{ inputs.minor }} `
+          -Patch ${{ inputs.patch }} `
+          -Build ${{ inputs.build }} `
           -Commit "${{ inputs.commit }}"
 inputs:
   minimum_supported_lv_version:


### PR DESCRIPTION
## Summary
- fix build-lvlibp action by using PowerShell line continuation characters so parameters are passed correctly to Build_lvlibp.ps1

## Testing
- `pwsh -NoProfile -Command "& './.github/actions/build-lvlibp/Build_lvlibp.ps1' -MinimumSupportedLVVersion '2021' -SupportedBitness '64' -RelativePath '.' -Major 1 -Minor 0 -Patch 0 -Build 0 -Commit 'abc'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689164afbe6c8329bf412d785ad04ae5