### PR TITLE
ci: update coding-hours workflow for tag pushes

### DIFF
--- a/.github/workflows/coding-hours.yml
+++ b/.github/workflows/coding-hours.yml
@@ -8,6 +8,9 @@ on:
       window_start:
         description: 'Report since YYYY‑MM‑DD'
         required: false
+  push:
+    tags:
+      - '*'
 
 permissions:
   contents: write
@@ -19,7 +22,7 @@ jobs:
 # Job 1 – run git‑hours (Go), build badge, commit to `metrics`
 ###############################################################################
   report:
-    if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/develop'||startsWith(github.ref,'refs/tags/')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/refresh-readme.yml
+++ b/.github/workflows/refresh-readme.yml
@@ -13,10 +13,16 @@ jobs:
   update-readme:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    env:
+      REF_BRANCH: >-
+        ${{ github.event.workflow_run.head_branch ||
+            github.event.repository.default_branch }}
 
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }        # develop branch by default
+        with:
+          fetch-depth: 0
+          ref: ${{ env.REF_BRANCH }}
 
       # Grab the helper
       - name: Run table refresh


### PR DESCRIPTION
## Summary
- run coding-hours workflow when tags are pushed
- refresh README on the branch associated with the coding-hours run

## Testing
- `yamllint .github/workflows/coding-hours.yml .github/workflows/refresh-readme.yml` *(fails: line length, indentation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689167419e2483298b24763f979cd90d