### PR TITLE
Fix rename-file action parameter passing and script error handling

### DIFF
--- a/.github/actions/rename-file/Rename-file.ps1
+++ b/.github/actions/rename-file/Rename-file.ps1
@@ -29,16 +29,17 @@ function Rename-File {
     
     # Check if the file exists
     if (-Not (Test-Path -Path $CurrentFilename)) {
-        Write-Host "Error: File '$CurrentFilename' does not exist."
-        return
+        Write-Error "File '$CurrentFilename' does not exist."
+        exit 1
     }
 
     # Attempt to rename the file
     try {
         Rename-Item -Path $CurrentFilename -NewName $NewFilename
-        Write-Host "Rename the packed project library to '$NewFilename'." .ps1
+        Write-Host "Renamed the packed project library to '$NewFilename'."
     } catch {
-        Write-Host "Error: Could not rename the file. $_"
+        Write-Error "Could not rename the file. $_"
+        exit 1
     }
 }
 

--- a/.github/actions/rename-file/action.yml
+++ b/.github/actions/rename-file/action.yml
@@ -12,8 +12,8 @@ runs:
     - name: Run Rename-file.ps1
       shell: pwsh
       run: |
-        & "${{ github.action_path }}/Rename-file.ps1" \
-          -CurrentFilename "${{ inputs.current_filename }}" \
+        & "${{ github.action_path }}/Rename-file.ps1" `
+          -CurrentFilename "${{ inputs.current_filename }}" `
           -NewFilename "${{ inputs.new_filename }}"
 inputs:
   current_filename:


### PR DESCRIPTION
## Summary
- use PowerShell line continuation characters in `rename-file` composite action so script receives parameters correctly
- harden `Rename-file.ps1` with proper error handling and clearer success message

## Testing
- `pwsh -NoLogo -NoProfile -Command "Set-Content tmp.txt 'hello'; ./.github/actions/rename-file/Rename-file.ps1 -CurrentFilename tmp.txt -NewFilename tmp2.txt; Test-Path tmp2.txt"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68917275949c83298f3c9b456bef656c