### PR TITLE
Enforce label-based semantic versioning

### DIFF
--- a/.github/actions/compute-version/README.md
+++ b/.github/actions/compute-version/README.md
@@ -1,6 +1,6 @@
 # Compute Version
 
-This composite action determines the semantic version for the build based on commit history, branch naming conventions and pull request labels.
+This composite action determines the semantic version for the build based on commit history, branch naming conventions and pull request labels. Pull requests must include exactly one of the labels `major`, `minor`, or `patch`; missing or conflicting labels cause the action to fail.
 
 ## Inputs
 - `github_token`: GitHub token with repository access.

--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -37,12 +37,20 @@ runs:
       with:
         github-token: ${{ inputs.github_token }}
         script: |
+          const allowed = ['major', 'minor', 'patch'];
           let bump = 'none';
           if (context.event_name === 'pull_request') {
             const labels = context.payload.pull_request.labels.map(l => l.name.toLowerCase());
-            if (labels.includes('major')) bump = 'major';
-            else if (labels.includes('minor')) bump = 'minor';
-            else if (labels.includes('patch')) bump = 'patch';
+            const found = labels.filter(l => allowed.includes(l));
+            if (found.length === 0) {
+              core.setFailed('Missing required release label: major, minor, or patch.');
+              return;
+            }
+            if (found.length > 1) {
+              core.setFailed(`Conflicting release labels detected: ${found.join(', ')}`);
+              return;
+            }
+            bump = found[0];
           }
           core.setOutput('bump_type', bump);
 

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -253,8 +253,8 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
    - If it’s `release/*`, might become `v1.3.0-rc.1-build46`.
 
 ### 7.2 Direct Push to Main or Develop
-- **Scenario**: You quickly push a fix to `develop` without a PR label.
-- **Action**: The workflow sees no label, so major/minor/patch remain unchanged. The build number increments automatically.
+- **Scenario**: You quickly push a fix to `develop` without opening a PR.
+- **Action**: With no pull request labels available, major/minor/patch remain unchanged while the build number increments automatically.
 - **Result**: The new tag might go from `v1.2.3-build46` → `v1.2.3-build47`.
 
 ### 7.3 Working on a Release Branch
@@ -329,8 +329,8 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 
 ## 10. **FAQ**
 
-**Q:** *How do I force a “patch” bump if I push directly to develop?*  
-**A:** You can edit the “Determine bump type” step to default to `patch` instead of `none` if no label is found.
+**Q:** *How do I force a “patch” bump if I push directly to develop?*
+**A:** Use a pull request with the `patch` label. Direct pushes without PR labels always use the previous version numbers.
 
 **Q:** *What if I want a final release immediately, without draft mode?*  
 **A:** Set `DRAFT_RELEASE: false`. Then your release is published the moment the workflow completes.

--- a/docs/ci/actions/multichannel-release-workflow.md
+++ b/docs/ci/actions/multichannel-release-workflow.md
@@ -47,8 +47,8 @@ By adopting these patterns, maintainers can run alpha, beta, and RC pipelines in
    - The GitHub Actions token (`GITHUB_TOKEN`) needs `contents: write` to push tags & create releases.  
    - If you have branch protection on tags, allow actions to create them.
 
-3. **Labels**  
-   - Pull requests must use `major`, `minor`, or `patch` to increment those fields. If no label, only the build number increments.
+3. **Labels**
+   - Pull requests must include exactly one of `major`, `minor`, or `patch` to increment those fields; missing or multiple labels cause the workflow to fail.
 
 4. **Fork Considerations**  
    - If `DISABLE_GPG_ON_FORKS == true`, the workflow sets `commit.gpgsign` and `tag.gpgsign` to `false` for forks (i.e., if the `github.repository` is not your official name).
@@ -184,8 +184,8 @@ Any commit to these branches triggers an alpha/beta/rc suffix. Merging to `main`
 4. **Final Merge**  
    - Typically, you merge alpha → beta → rc → main in sequence, each step dropping the old suffix for the new. If you do “hotfix” merges or skip channels, ensure you keep version consistency.
 
-5. **Same Bump Type**  
-   - The label-based bump is orthogonal to alpha/beta/rc. If no label is set, major/minor/patch remain the same, but you might still produce `-alpha.<N>-buildXX`.
+5. **Same Bump Type**
+   - The label-based bump is orthogonal to alpha/beta/rc. Exactly one release label is still required; missing or multiple labels will fail the workflow.
 
 
 <a name="faq"></a>

--- a/docs/ci/troubleshooting-faq.md
+++ b/docs/ci/troubleshooting-faq.md
@@ -101,7 +101,7 @@ Below are 14 possible issues you might encounter, along with suggested steps to 
 
 **Possible Causes**:
 - The workflow only checks for certain labels (`major`, `minor`, `patch`). Typos or different capitalization might be ignored.
-- You’re pushing directly to a branch instead of creating a PR (so no label is read).
+- You’re pushing directly to a branch instead of creating a PR. Version bumps require a labeled pull request.
 
 **Solution**:
 1. Make sure the label is exactly `major`, `minor`, or `patch` in lowercase (unless your workflow script also checks for capitalized labels).  

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -66,9 +66,8 @@ This workflow ensures that all **forks** of the repository can sync the latest b
 3. **Check Environment Variables**  
    - Decide on `DRAFT_RELEASE`, `USE_AUTO_NOTES`, `ATTACH_ARTIFACTS_TO_RELEASE`, `DISABLE_GPG_ON_FORKS`, etc. (see [Environment Variables](#32-environment-variables)).
 
-4. **Make a Pull Request and Label It**  
-   - Use labels `major`, `minor`, or `patch` if you need a version bump.  
-   - If no label is found, only the build number increments.
+4. **Make a Pull Request and Label It**
+   - Apply exactly one of `major`, `minor`, or `patch` to request a version bump. The workflow fails if none or multiple release labels are present.
 
 5. **Merge to the Appropriate Branch**  
    - In Gitflow, typical merges go from **feature** → **develop**, then eventually to:
@@ -296,8 +295,8 @@ Merging into these branches (or pushing directly to them) triggers a **pre-relea
 ### 5.4 Version Bumps via Labels
 
 When you open a **Pull Request** into `develop`, `release-alpha/*`, or `release-beta/*` (or even `main`/`hotfix/*`):
-- A label of `major`, `minor`, or `patch` increments that segment of the version (e.g., `1.2.3` → `2.0.0` if `major`, etc.).  
-- If **no** label is present, the major/minor/patch remains the same (only the build number increments).
+- You must apply exactly one of the labels `major`, `minor`, or `patch` to increment the corresponding version segment (e.g., `1.2.3` → `2.0.0` if `major`, etc.).
+- The workflow fails if none of these labels is present or if multiple release labels are applied.
 
 > **Note**: This means you can version-bump **incrementally** while merging into `develop` (to reflect that new features are in development), or you can wait until you merge to a pre-release branch. Each time the build runs, the resulting `.vip` has an updated version (with a new build number, plus any alpha/beta/rc suffix if applicable).
 


### PR DESCRIPTION
## Summary
- validate pull request labels `major`, `minor`, or `patch` before computing version
- document requirement for exactly one release label across CI docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689176ada9c08329a8a01dcd48c45704