### PR TITLE
feat: default compute-version to patch

### DIFF
--- a/.github/actions/compute-version/README.md
+++ b/.github/actions/compute-version/README.md
@@ -1,6 +1,6 @@
 # Compute Version
 
-This composite action determines the semantic version for the build based on commit history, branch naming conventions and pull request labels. Pull requests must include exactly one of the labels `major`, `minor`, or `patch`; missing or conflicting labels cause the action to fail.
+This composite action determines the semantic version for the build based on commit history, branch naming conventions and pull request labels. Pull requests should include exactly one of the labels `major`, `minor`, or `patch`. If no label is present, the action defaults to `patch`; conflicting labels still cause the action to fail.
 
 ## Inputs
 - `github_token`: GitHub token with repository access.

--- a/.github/actions/compute-version/action.yml
+++ b/.github/actions/compute-version/action.yml
@@ -42,15 +42,11 @@ runs:
           if (context.event_name === 'pull_request') {
             const labels = context.payload.pull_request.labels.map(l => l.name.toLowerCase());
             const found = labels.filter(l => allowed.includes(l));
-            if (found.length === 0) {
-              core.setFailed('Missing required release label: major, minor, or patch.');
-              return;
-            }
             if (found.length > 1) {
               core.setFailed(`Conflicting release labels detected: ${found.join(', ')}`);
               return;
             }
-            bump = found[0];
+            bump = found[0] || 'patch';
           }
           core.setOutput('bump_type', bump);
 


### PR DESCRIPTION
# GitHub Issue for the Pull Request
N/A

# GitHub Discussions Related to this Pull Request
N/A

# Checklists
- [ ] I do not require assistance from NI to complete any of the following checks.
- [ ] The changes in this PR are based on the appropriate NI-repo feature branch
- [ ] I am submitting the changes in this PR to the appropriate NI-repo feature branch
- [ ] I built a VI Package using the [Powershell build tool](https://github.com/ni/labview-icon-editor/wiki/automation#pwsh).
- [ ] I installed the VI Package produced by the Powershell build tool and tested my change.
- [ ] I tested my changes after [installing the VI package](https://github.com/ni/labview-icon-editor/wiki/test#localtesting).
- [ ] NI has my contributor license agreement.

# Summary of Changes
- Default compute-version action to use patch when no release label is present.
- Update README to describe the new default behavior.

# Reason for Change
Pull requests without a version label previously caused the compute-version step to fail. Defaulting to `patch` prevents the workflow from getting stuck while still flagging conflicting labels.

# Visual Aids
N/A

# Additional Information
N/A

# Testing

## Manual Tests
- Ran a Node.js snippet to verify that missing labels default to `patch`.
- Attempted to run PowerShell scripts, but `pwsh` was not available in the environment.


------
https://chatgpt.com/codex/tasks/task_e_689178473b008329a84e714da095579b