### PR TITLE
fix: compress display info JSON

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -209,7 +209,7 @@ jobs:
             "Product Description" = ""
             "Release Notes - Change Log" = ""
           }
-          $json = $info | ConvertTo-Json -Depth 5
+          $json = $info | ConvertTo-Json -Depth 5 -Compress
           "json=$json" >> $Env:GITHUB_OUTPUT
       - uses: ./.github/actions/modify-vipb-display-info
         with:


### PR DESCRIPTION
## Summary
- compress display info JSON in workflow so it's written to `GITHUB_OUTPUT` as a single line

## Testing
- `actionlint .github/workflows/ci-composite.yml` *(fails: checkout v3 too old and `self-hosted-windows-lv` label unknown)*

------
https://chatgpt.com/codex/tasks/task_e_6891818704cc8329803c2e60d5ffb433