### PR TITLE
fix: use ps line continuation for vip build actions

### DIFF
--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -12,18 +12,18 @@ runs:
     - name: Run build_vip.ps1
       shell: pwsh
       run: |
-        & "${{ github.action_path }}/build_vip.ps1" \
-          -SupportedBitness ${{ inputs.supported_bitness }} \
-          -RelativePath "${{ inputs.relative_path }}" \
-          -VIPBPath "${{ inputs.vipb_path }}" \
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
-          -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} \
-          -Major ${{ inputs.major }} \
-          -Minor ${{ inputs.minor }} \
-          -Patch ${{ inputs.patch }} \
-          -Build ${{ inputs.build }} \
-          -Commit "${{ inputs.commit }}" \
-          -ReleaseNotesFile "${{ inputs.release_notes_file }}" \
+        & "${{ github.action_path }}/build_vip.ps1" `
+          -SupportedBitness ${{ inputs.supported_bitness }} `
+          -RelativePath "${{ inputs.relative_path }}" `
+          -VIPBPath "${{ inputs.vipb_path }}" `
+          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} `
+          -Major ${{ inputs.major }} `
+          -Minor ${{ inputs.minor }} `
+          -Patch ${{ inputs.patch }} `
+          -Build ${{ inputs.build }} `
+          -Commit "${{ inputs.commit }}" `
+          -ReleaseNotesFile "${{ inputs.release_notes_file }}" `
           -DisplayInformationJSON '${{ inputs.display_information_json }}'
 inputs:
   supported_bitness:

--- a/.github/actions/modify-vipb-display-info/action.yml
+++ b/.github/actions/modify-vipb-display-info/action.yml
@@ -12,18 +12,18 @@ runs:
     - name: Run ModifyVIPBDisplayInfo.ps1
       shell: pwsh
       run: |
-        & "${{ github.action_path }}/ModifyVIPBDisplayInfo.ps1" \
-          -SupportedBitness ${{ inputs.supported_bitness }} \
-          -RelativePath "${{ inputs.relative_path }}" \
-          -VIPBPath "${{ inputs.vipb_path }}" \
-          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} \
-          -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} \
-          -Major ${{ inputs.major }} \
-          -Minor ${{ inputs.minor }} \
-          -Patch ${{ inputs.patch }} \
-          -Build ${{ inputs.build }} \
-          -Commit "${{ inputs.commit }}" \
-          -ReleaseNotesFile "${{ inputs.release_notes_file }}" \
+        & "${{ github.action_path }}/ModifyVIPBDisplayInfo.ps1" `
+          -SupportedBitness ${{ inputs.supported_bitness }} `
+          -RelativePath "${{ inputs.relative_path }}" `
+          -VIPBPath "${{ inputs.vipb_path }}" `
+          -MinimumSupportedLVVersion ${{ inputs.minimum_supported_lv_version }} `
+          -LabVIEWMinorRevision ${{ inputs.labview_minor_revision }} `
+          -Major ${{ inputs.major }} `
+          -Minor ${{ inputs.minor }} `
+          -Patch ${{ inputs.patch }} `
+          -Build ${{ inputs.build }} `
+          -Commit "${{ inputs.commit }}" `
+          -ReleaseNotesFile "${{ inputs.release_notes_file }}" `
           -DisplayInformationJSON '${{ inputs.display_information_json }}'
 inputs:
   supported_bitness:


### PR DESCRIPTION
## Summary
- fix ModifyVIPBDisplayInfo composite action to use PowerShell backtick continuation
- fix Build VI Package composite action similarly to avoid missing params

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689187a3979c83298d92008e6b7c53e2