### PR TITLE
Generate release notes in build-vip workflow

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -180,6 +180,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Generate release notes
+        uses: ./.github/actions/generate-release-notes
+        # output_path defaults to Tooling/deployment/release_notes.md
       - uses: actions/download-artifact@v4
         with:
           name: lv_icon_x86.lvlibp


### PR DESCRIPTION
## Summary
- generate release notes before artifact downloads in build-vip job

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689189f85a6c8329a1795fafdcd4634b