### PR TITLE
Add release notes generation to build-vip job

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -180,6 +180,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Generate release notes
+        uses: ./.github/actions/generate-release-notes
+        # output_path defaults to Tooling/deployment/release_notes.md
       - uses: actions/download-artifact@v4
         with:
           name: lv_icon_x86.lvlibp


### PR DESCRIPTION
## Summary
- generate release notes during the build-vip job before artifacts are downloaded

## Testing
- `yamllint .github/workflows/ci-composite.yml` (fails: too many spaces after colon, line too long, etc.)
- `npm test` (fails: ENOENT no package.json)
- `pytest` (passes: no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68918a8e40688329ad51443d0f559832