### PR TITLE
Upload build artifacts for VI Package and release notes

### DIFF
--- a/.github/actions/build-vip/action.yml
+++ b/.github/actions/build-vip/action.yml
@@ -25,6 +25,18 @@ runs:
           -Commit "${{ inputs.commit }}" `
           -ReleaseNotesFile "${{ inputs.release_notes_file }}" `
           -DisplayInformationJSON '${{ inputs.display_information_json }}'
+
+    - name: Upload release notes
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-notes
+        path: ${{ inputs.release_notes_file }}
+
+    - name: Upload VI Package
+      uses: actions/upload-artifact@v4
+      with:
+        name: vi-package
+        path: builds/VI Package/*.vip
 inputs:
   supported_bitness:
     description: '32 or 64'


### PR DESCRIPTION
## Summary
- upload build release notes as GitHub Actions artifacts
- upload generated VI Package as GitHub Actions artifact

## Testing
- `npx actionlint .github/workflows/ci-composite.yml .github/actions/build-vip/action.yml` *(fails: could not determine executable to run)*
- `curl -L -o /tmp/actionlint.tar.gz https://github.com/rhysd/actionlint/releases/latest/download/actionlint_linux_amd64.tar.gz && tar -xzf /tmp/actionlint.tar.gz -C /tmp && /tmp/actionlint -version && /tmp/actionlint .github/workflows/ci-composite.yml .github/actions/build-vip/action.yml` *(fails: gzip: stdin: not in gzip format)*

------
https://chatgpt.com/codex/tasks/task_e_6891a1ea36808329909a2111227b1415