### PR TITLE
docs: clarify build prerequisites and release behavior

### DIFF
--- a/docs/automated-setup.md
+++ b/docs/automated-setup.md
@@ -24,7 +24,7 @@ This document describes how to **build, test, and distribute** the **LabVIEW Ico
   - Debug locally the same steps used in CI, ensuring consistent results.
 
 - **Prerequisites**:
-  1. **LabVIEW 2021 SP1 (both 32-bit and 64-bit)**.  
+  1. **LabVIEW 2021 SP1 (both 32-bit and 64-bit)** and **LabVIEW 2023 (64-bit) for package building**.
   2. **PowerShell 7+** and **Git**.  
   3. **Apply** `Tooling\deployment\runner_dependencies.vipc` **(to both 32-bit and 64-bit)**.
 
@@ -102,7 +102,7 @@ We provide **GitHub Actions** that wrap these same PowerShell scripts for buildi
 
 - **Development Mode Toggle**: Uses `Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`.  
 - **Run Unit Tests**: Calls `unit_tests.ps1`.  
-- **Build VI Package and Release**: Internally calls `Build.ps1` to produce a `.vip` and create a GitHub Release.  
+- **Build VI Package**: Internally calls `Build.ps1` to produce a `.vip` artifact (and can draft a release if configured).
 
 ### Injecting Organization/Repo for Unique Builds
 


### PR DESCRIPTION
## Summary
- note requirement for LabVIEW 2023 (64-bit) alongside 2021 SP1
- clarify build workflow produces a .vip artifact and only drafts releases if configured

## Testing
- `pwsh .github/actions/unit-tests/unit_tests.ps1 -RelativePath "$PWD"` *(fails: RunUnitTests.ps1 missing LabVIEW)*

------
https://chatgpt.com/codex/tasks/task_e_68924e3355d08329a6cd7f41ada54d86