### PR TITLE
chore: update actions versions

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Determine if CI should run
         id: check
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -122,7 +122,7 @@ jobs:
     outputs:
       vipc: ${{ steps.filter.outputs.vipc }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - id: filter
@@ -246,7 +246,7 @@ jobs:
     needs: [build-ppl, version]
     runs-on: self-hosted-windows-lv
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Generate release notes


### PR DESCRIPTION
## Summary
- bump actions/github-script to v7
- use actions/checkout v4 in composite CI workflow

## Testing
- `yamllint .github/workflows/ci-composite.yml` *(fails: too many spaces after colon, line too long, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68927cd6fbf08329b87a61507c8c6bb5