### PR TITLE
ci: checkout repo before computing version

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -174,6 +174,7 @@ jobs:
       BUILD:         ${{ steps.compute.outputs.BUILD }}
       IS_PRERELEASE: ${{ steps.compute.outputs.IS_PRERELEASE }}
     steps:
+      - uses: actions/checkout@v3
       - id: compute
         uses: ./.github/actions/compute-version
         with:


### PR DESCRIPTION
## Summary
- checkout repository before running compute-version action

## Testing
- `yamllint -c /tmp/yamllint.yml .github/workflows/ci-composite.yml`


------
https://chatgpt.com/codex/tasks/task_e_68928624a9fc832998d5af24b861e759