### PR TITLE
docs: refocus maintainer guide on technical workflows

### DIFF
--- a/docs/ci/actions/maintainers-guide.md
+++ b/docs/ci/actions/maintainers-guide.md
@@ -1,50 +1,41 @@
-# Maintainers Guide
+# Maintainers Technical Guide
 
-## Introduction
+This guide is a technical reference for maintainers working in the LabVIEW Icon
+Editor repository. It outlines the workflows and GitHub Actions used to manage
+branches, run continuous integration (CI), and finalize releases.
 
-Maintainers of the LabVIEW Icon Editor project handle day-to-day repository upkeep, oversee contributions, and coordinate with NI’s Open-Source Program. This guide outlines the responsibilities and processes for maintainers.
+## Feature Branch Workflow
 
-*(For details on overall project governance—Steering Committee roles and the BDFL approach—see [**`GOVERNANCE.md`**](../../../GOVERNANCE.md).)*
+1. Confirm the related GitHub issue is approved for work.
+2. Create a branch from `develop` named `issue-<number>-<short-description>`
+   (for example, `issue-123-fix-toolbar`).
+3. Set the issue's **Status** field to `In Progress`. The
+   [composite CI workflow](../../../.github/workflows/ci-composite.yml) skips
+   most jobs when the status is not set.
+4. Push the branch to the main repository and open a pull request targeting
+   `develop` (or another appropriate branch).
+5. Ensure CI passes and obtain at least one maintainer approval before merging.
 
-## Role of Maintainers
+## Workflow Administration
 
-- **Code Reviews and Merging** – Review incoming pull requests for quality, style, and alignment with project goals. Only maintainers (and the Steering Committee) have write access to merge PRs. All merges follow the rule of passing CI and at least one maintainer approval.  
-- **Issue Triage** – Regularly monitor GitHub Issues and Discussions. Label issues appropriately (e.g., bugs, enhancements, “Workflow: Open to contribution”), and close or consolidate duplicates.
-- **Community Support** – Engage on Discord and Discussion forums to answer contributor questions. Help new contributors find starter issues.
-- **Releases** – Work with NI release engineers or the Open-Source Program Manager to coordinate publishing new versions. Maintainers ensure that the `develop` branch is ready for release merges into `main`.
+- **Approve experiment branches** – When an experiment branch should publish
+  artifacts (VIPs), run the `approve-experiment` workflow in GitHub Actions.
+  Coordinate with the NI Open-Source Program Manager (OSPM) before execution.
+- **Finalize experiment merges** – Prior to merging an experiment branch into
+  `develop`, apply an appropriate version label (major/minor/patch) and remove
+  any temporary settings or `NoCI` labels. The OSPM or designated NI staff
+  typically gives the final approval.
+- **Hotfix branches** – For critical fixes on an official release, create or
+  approve a `hotfix/*` branch targeting `main`. After merging into `main`, merge
+  the changes back into `develop` to keep branches synchronized.
 
-## Creating Feature Branches
+## Release Preparation
 
-When an issue is approved for work, maintainers must create a branch tied directly to that issue so the CI pipeline can validate its status.
+Maintainers ensure that `develop` remains in a releasable state. Coordinate with
+release engineers or the OSPM to merge into `main` and publish packages when a
+release is planned.
 
-1. **Name the branch** `issue-<number>-<short-description>` (for example, `issue-123-fix-toolbar`).
-2. **Set the issue’s Status** field to `In Progress`. The [composite CI workflow](../../../.github/workflows/ci-composite.yml) checks this field and will skip most jobs if the issue is not marked in progress.
-3. **Branch from `develop`** and push the branch to the main repository so contributors can begin work.
-4. **Open PRs** from the `issue-<number>` branch into `develop` (or another target as appropriate).
+## Additional Resources
 
-This process ensures that each feature branch is traceable to a GitHub issue and that CI only runs for actively tracked work.
-
-## Admin Tasks and Final Merges
-
-Certain actions require NI administrative oversight or special approval:
-
-- **Experiment Branch Approval** – When a long-lived experiment branch is ready to distribute artifacts (VIPs), a maintainer coordinates with the NI Open-Source Program Manager (OSPM) to run the “approve-experiment” workflow. This enables CI artifact publishing for that experiment branch.
-- **Finalizing Experiment Merges** – After an experiment concludes, maintainers help prepare the final merge into `develop`. This includes ensuring a proper version label (major/minor/patch) is applied and that any “NoCI” labels or temporary settings are cleaned up. The OSPM or designated NI staff will typically give the final go-ahead for the merge after Steering Committee approval.  
-- **Critical Hotfixes** – In rare cases (e.g., a critical issue in an official release), maintainers may create or approve a `hotfix/*` branch targeting `main`. Such hotfixes should be done in coordination with NI (to ensure the fix is included in official builds). After merging into `main`, the changes should also be merged back into `develop` to keep branches in sync.
-
-## Best Practices for Maintainers
-
-- **Consistency** – Follow the project’s coding standards and guidelines (see CONTRIBUTING.md) when reviewing or writing code. This sets an example for external contributors.  
-- **Communication** – Keep the community informed. If you merge a significant PR or introduce a new requirement (e.g., a new build step), mention it in the project’s Discussion forum or release notes.  
-- **Transparency** – Except for confidential matters (like security issues before disclosure), conduct discussions in public channels (issues, PRs, discussions) rather than private emails. This ensures community members can stay informed and contribute.  
-- **Inclusive Culture** – Encourage contributions of all kinds (code, docs, testing). Recognize and thank community members for their efforts. If someone’s PR isn’t up to standard, provide constructive feedback and guidance rather than closing without explanation.  
-- **Upstream Sync** – Keep your local repository and any forks you maintain updated with the latest `develop` branch. This helps in testing and in guiding contributors (so you catch integration issues early).
-
-## Continuous Improvement
-
-Maintainers are also responsible for improving project infrastructure over time:
-- Propose and implement workflow enhancements (for CI, code quality checks, etc.). 
-- Update documentation when processes change or new tools are adopted. 
-- Mentor new maintainers as the team grows, sharing knowledge about the project’s history and decisions.
-
-By adhering to this guide, maintainers ensure that the LabVIEW Icon Editor project remains healthy, collaborative, and aligned with both community needs and NI’s quality standards.
+- Repository governance is described in [GOVERNANCE.md](../../../GOVERNANCE.md).
+- Action-specific documentation is available in this directory's other guides.


### PR DESCRIPTION
## Summary
- rewrite `docs/ci/actions/maintainers-guide.md` to provide a concise technical reference for maintainers
- document feature branch workflow and CI administration steps
- outline release preparation requirements and link to related guides

## Testing
- `npx markdownlint-cli docs/ci/actions/maintainers-guide.md`


------
https://chatgpt.com/codex/tasks/task_e_6892a156675483298e9489cabfc2c95c