### PR TITLE
docs: refine maintainers guide

### DIFF
--- a/docs/ci/actions/maintainers-guide.md
+++ b/docs/ci/actions/maintainers-guide.md
@@ -2,7 +2,21 @@
 
 This guide is a technical reference for maintainers working in the LabVIEW Icon
 Editor repository. It outlines the workflows and GitHub Actions used to manage
-branches, run continuous integration (CI), and finalize releases.
+branches, run continuous integration (CI), and finalize releases. In addition to
+the steps below, maintainers are expected to triage issues, keep dependencies up
+to date, and ensure that published guidance across the repository remains
+current.
+
+## Maintainer Responsibilities
+
+- **Issue Triage** – Label new issues, confirm reproduction steps, and mark
+  items that are ready for community contribution.
+- **Branch Hygiene** – Delete merged branches, keep `develop` rebased on
+  `main`, and close stale pull requests after consultation with the author.
+- **CI Upkeep** – Periodically review workflow runs and update GitHub Actions
+  versions or build scripts when they go out of support.
+- **Community Support** – Respond to discussion threads and provide direction
+  to contributors in pull requests and issues.
 
 ## Feature Branch Workflow
 
@@ -14,7 +28,9 @@ branches, run continuous integration (CI), and finalize releases.
    most jobs when the status is not set.
 4. Push the branch to the main repository and open a pull request targeting
    `develop` (or another appropriate branch).
-5. Ensure CI passes and obtain at least one maintainer approval before merging.
+5. Run unit tests or scripted checks locally whenever possible.
+6. Ensure CI passes and obtain at least one maintainer approval before merging.
+7. After merging, delete the source branch to keep the repository tidy.
 
 ## Workflow Administration
 
@@ -28,12 +44,24 @@ branches, run continuous integration (CI), and finalize releases.
 - **Hotfix branches** – For critical fixes on an official release, create or
   approve a `hotfix/*` branch targeting `main`. After merging into `main`, merge
   the changes back into `develop` to keep branches synchronized.
+- **Documentation updates** – When workflows change, update related
+  documentation in the `/docs` directory as part of the same pull request.
+
+## Pull Request Review Checklist
+
+- The pull request references a tracked issue and targets the correct branch.
+- Commit messages are clear and follow repository conventions.
+- CI jobs complete successfully and any failures are explained.
+- Documentation and tests are added or updated as needed.
 
 ## Release Preparation
 
-Maintainers ensure that `develop` remains in a releasable state. Coordinate with
-release engineers or the OSPM to merge into `main` and publish packages when a
-release is planned.
+Maintainers ensure that `develop` remains in a releasable state:
+
+1. Verify version labels and changelog entries reflect upcoming changes.
+2. Confirm that CI is green on `develop` and `main`.
+3. Coordinate with release engineers or the OSPM to merge into `main` and
+   publish packages when a release is planned.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary
- expand maintainer responsibilities for issue triage, branch hygiene, and CI upkeep
- add review checklist and release preparation details
- document documentation update expectations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a35f588c8329ac038b21d13f84a6