### PR TITLE
Expand CI release branch triggers

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -13,14 +13,18 @@ on:
     branches:
       - main
       - develop
-      - release/*
+      - release-alpha/*
+      - release-beta/*
+      - release-rc/*
       - feature/*
       - hotfix/*
   pull_request:
     branches:
       - main
       - develop
-      - release/*
+      - release-alpha/*
+      - release-beta/*
+      - release-rc/*
       - feature/*
       - hotfix/*
     types:

--- a/docs/ci/actions/multichannel-release-workflow.md
+++ b/docs/ci/actions/multichannel-release-workflow.md
@@ -63,12 +63,14 @@ By adopting these patterns, maintainers can run alpha, beta, and RC pipelines in
 2. **Beta**  
    - Branch pattern: `release-beta/*`.  
    - Produces `vX.Y.Z-beta.<N>-build<commitCount>`.  
-3. **RC**  
-   - Branch pattern: `release-rc/*`.  
-   - Produces `vX.Y.Z-rc.<N>-build<commitCount>`.  
-4. **Other Branches**  
-   - `main`, `develop`, `hotfix/*` produce final releases with no alpha/beta/rc suffix.  
-   - No label => major/minor/patch remain unchanged; build increments only.
+3. **RC**
+  - Branch pattern: `release-rc/*`.
+  - Produces `vX.Y.Z-rc.<N>-build<commitCount>`.
+4. **Other Branches**
+  - `main`, `develop`, `hotfix/*` produce final releases with no alpha/beta/rc suffix.
+  - No label => major/minor/patch remain unchanged; build increments only.
+
+The accompanying GitHub Actions workflow (`ci-composite.yml`) lists `release-alpha/*`, `release-beta/*`, and `release-rc/*` in its trigger patterns so commits or pull requests to these branches automatically run this pipeline.
 
 Use whichever patterns best fit your project’s branching model. If you prefer subdirectories (`release/alpha/*` vs. `release-alpha/*`), adapt the snippet accordingly.
 

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -257,6 +257,7 @@ All dev-mode logic resides in two PowerShell scripts:
     - **Attach to Release**: If release creation is enabled (`ATTACH_ARTIFACTS_TO_RELEASE == true`), attach the built `.vip` to a GitHub Release.
 - **Events**: Typically triggered on:
   - Push or PR to `develop`, `feature/*`, `release-alpha/*`, `release-beta/*`, `release-rc/*`, `main`, or `hotfix/*`.
+    The workflow explicitly lists these pre-release patterns and does **not** use a generic `release/*` trigger.
   - Might also be triggered manually (`workflow_dispatch`) if needed.
 
 ---
@@ -273,7 +274,7 @@ All dev-mode logic resides in two PowerShell scripts:
 - **`release/*`**: branched off `develop` when nearing release.  
 - **`hotfix/*`**: branched off `main` for urgent fixes.  
 
-In this repo, we extend the concept of `release/*` into **`release-alpha/*`, `release-beta/*`, and `release-rc/*`** to differentiate pre-release stages. Merges flow as:
+In this repo, we extend the concept of `release/*` into **`release-alpha/*`, `release-beta/*`, and `release-rc/*`** to differentiate pre-release stages. The CI workflow mirrors this by triggering on these exact patterns. Merges flow as:
 - **feature** → **develop** → **release-alpha/X.Y** → **release-beta/X.Y** → **release-rc/X.Y** → **main**.
 
 <a name="52-multi-channel-pre-releases"></a>


### PR DESCRIPTION
## Summary
- expand CI workflow triggers to release-alpha, release-beta, and release-rc branch patterns
- document explicit pre-release branch triggers in CI guide and multichannel release doc

## Testing
- `yamllint .github/workflows/ci-composite.yml`
- `markdownlint docs/powershell-cli-github-action-instructions.md docs/ci/actions/multichannel-release-workflow.md`


------
https://chatgpt.com/codex/tasks/task_e_6893a328d8d08329ae34b23aca1cfa6c