### PR TITLE
docs: clarify triggers for pre-release branches

### DIFF
--- a/docs/ci/actions/multichannel-release-workflow.md
+++ b/docs/ci/actions/multichannel-release-workflow.md
@@ -72,6 +72,30 @@ By adopting these patterns, maintainers can run alpha, beta, and RC pipelines in
 
 The accompanying GitHub Actions workflow (`ci-composite.yml`) lists `release-alpha/*`, `release-beta/*`, and `release-rc/*` in its trigger patterns so commits or pull requests to these branches automatically run this pipeline.
 
+To enable these pre-release branches, ensure the workflow's `on.push.branches` and `on.pull_request.branches` sections include the patterns:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - release-alpha/*
+      - release-beta/*
+      - release-rc/*
+      - feature/*
+      - hotfix/*
+  pull_request:
+    branches:
+      - main
+      - develop
+      - release-alpha/*
+      - release-beta/*
+      - release-rc/*
+      - feature/*
+      - hotfix/*
+```
+
 Use whichever patterns best fit your project’s branching model. If you prefer subdirectories (`release/alpha/*` vs. `release-alpha/*`), adapt the snippet accordingly.
 
 


### PR DESCRIPTION
## Summary
- document that alpha, beta, and RC branches need `release-*` patterns in `.github/workflows/ci-composite.yml`
- show YAML snippet updating `on.push.branches` and `on.pull_request.branches`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_6893a4ac8fcc832999b77136ce411da8