### PR TITLE
docs: align runner labels and release behavior

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -1,6 +1,6 @@
 # Local CI/CD Workflows
 
-This document explains how to automate build, test, and distribution steps for the Icon Editor using GitHub Actions. It includes features such as **fork-friendly GPG signing** toggles, **automatic version bumping** (using labels), and the **release creation** process. Additionally, it shows how you can **brand** the resulting VI Package with **organization** and **repository** metadata for unique identification.
+This document explains how to automate build, test, and distribution steps for the Icon Editor using GitHub Actions. It includes features such as **fork-friendly GPG signing** toggles, **automatic version bumping** (using labels), and **artifact upload**. Additionally, it shows how you can **brand** the resulting VI Package with **organization** and **repository** metadata for unique identification.
 
 ---
 
@@ -49,6 +49,7 @@ Automating your Icon Editor builds and tests:
 4. **Run Tests**
    Use the main CI workflow (`ci-composite.yml`) to confirm your environment is valid.
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
+   - CI jobs proceed only when your branch is named `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. See the [`issue-status` job](../.github/workflows/ci-composite.yml#L39) for details.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically, **including** optional metadata fields (`-CompanyName`, `-AuthorName`) that let you **brand** your package.
@@ -122,7 +123,7 @@ The `build-ppl` job uses a matrix to produce both bitnesses rather than distinct
    Go to **Settings → Actions → Runners** in your GitHub repository (or organization) and follow the steps to register a runner on your machine that has LabVIEW installed.
 
 3. **Label the Runner** (optional):  
-   - You may label it `self-hosted, iconeditor` (or adjust the workflow’s `runs-on` lines to match your chosen labels).  
+   - Use labels such as `self-hosted-windows-lv` (and `self-hosted-linux-lv` for Linux). Adjust the workflow’s `runs-on` lines to match your runner labels.
    - This helps ensure the correct environment is used for building the Icon Editor.
 
 ---

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -107,7 +107,7 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 - **Fork Setup**:
   1. **Copy** the workflow file (`.github/workflows/ci-composite.yml`) into your fork.
   2. **Update** any references to the official repo name (`ni/labview-icon-editor`) if your fork is named differently.
-  3. **Self-Hosted Runner**: Confirm your runner has the `iconeditor` label or update `runs-on` to match your runner’s labels.
+ 3. **Self-Hosted Runner**: Confirm your runner uses the `self-hosted-windows-lv` label (or `self-hosted-linux-lv` for Linux jobs) or update `runs-on` to match your runner’s labels.
   4. **Write Permissions**: In fork settings → Actions → General, ensure “Workflow Permissions” = “Read and write.”
 
 ### 3.4 Artifact Publication
@@ -120,7 +120,7 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 ### 4.1 Pipeline Overview
 
 1. **Check Out & Full Clone**
-   - Uses `actions/checkout@v3` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
+   - Uses `actions/checkout@v4` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
 
 2. **Determine Bump Type**
    - On PR events, scans the PR labels: `major`, `minor`, `patch`, or defaults to `none`.  
@@ -177,15 +177,15 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 ## 6. **Maintenance & Administration**
 
 ### 6.1 Keeping the Workflow Updated
-1. **Actions Versions**  
-   - This workflow references certain actions, like `actions/checkout@v3` or `actions/github-script@v6`. Keep an eye on updates or deprecations.
+1. **Actions Versions**
+   - This workflow references certain actions, like `actions/checkout@v4` or `actions/github-script@v7`. Keep an eye on updates or deprecations.
 2. **Build Actions**
    - If your LabVIEW project evolves or you add steps, keep the `build-lvlibp` and `build-vip` actions up to date.
 3. **Windows Runner Updates**  
    - Ensure your self-hosted runner OS is patched and has any new LabVIEW versions if your project updates.
 
 ### 6.2 Runner Management
-- **Labels**: The workflow uses `runs-on: [self-hosted, iconeditor]`. Confirm your runner has both `self-hosted` and `iconeditor` labels.
+- **Labels**: The workflow uses `runs-on: self-hosted-windows-lv` (and `self-hosted-linux-lv` where applicable). Confirm your runner has the required label.
 - **Resource Monitoring**: If the build is large or slow, upgrade the machine specs or add more runners to handle parallel tasks.
 
 ### 6.3 Adding New Features

--- a/docs/ci/actions/multichannel-release-workflow.md
+++ b/docs/ci/actions/multichannel-release-workflow.md
@@ -11,7 +11,7 @@ This revised guide focuses on the **release workflow**, specifically how we hand
 4. [Workflow Steps](#workflow-steps)
    - [Fetch & Determine Version](#fetch--determine-version)
    - [Build & Artifact Handling](#build--artifact-handling)
-   - [Tag & Release Creation](#tag--release-creation)
+   - [Artifact Upload Only](#artifact-upload-only)
 5. [Multiple Pre-Release Channels Explained](#multiple-pre-release-channels-explained)  
    - [Branch Name Conventions](#branch-name-conventions)  
    - [Alpha / Beta / RC Logic](#alpha--beta--rc-logic)  
@@ -25,7 +25,7 @@ This revised guide focuses on the **release workflow**, specifically how we hand
 <a name="overview--purpose"></a>
 ## **1. Overview & Purpose**
 
-This **Multi-Channel Release Workflow** automates the packaging and releasing of LabVIEW `.vip` files. It:
+This **Multi-Channel Release Workflow** automates packaging LabVIEW `.vip` files for multiple pre-release channels. It uploads artifacts but does not create Git tags or GitHub releases. It:
 
 - Uses **label-based** semantic version increments for major/minor/patch.
 - Maintains a **commit-based build number**, so every new commit yields a unique suffix (`-buildNN`).
@@ -41,9 +41,9 @@ By adopting these patterns, maintainers can run alpha, beta, and RC pipelines in
    - LabVIEW installed to build `.vip` files.  
    - PowerShell 7+ recommended.
 
-2. **Repository Permissions**  
-   - The GitHub Actions token (`GITHUB_TOKEN`) needs `contents: write` to push tags & create releases.  
-   - If you have branch protection on tags, allow actions to create them.
+2. **Repository Permissions**
+   - The GitHub Actions token (`GITHUB_TOKEN`) needs `contents: read` to upload artifacts.
+   - Creating tags or GitHub releases would require additional permissions and a separate workflow.
 
 3. **Labels**
    - Pull requests may include at most one of `major`, `minor`, or `patch` to increment those fields. If none is provided, the workflow defaults to a patch bump. Multiple release labels cause the workflow to fail. See [`compute-version`](../../.github/actions/compute-version/action.yml) for the label-handling logic.
@@ -113,15 +113,11 @@ Below is a **high-level** breakdown. In your `.github/workflows/ci-composite.yml
 <a name="build--artifact-handling"></a>
 ### **Build & Artifact Handling**
 - Uses the `build-lvlibp` and `build-vip` actions to compile code and produce the `.vip` package.
-- Uploads the `.vip` as an ephemeral artifact with `actions/upload-artifact@v4`.
 
-<a name="tag--release-creation"></a>
-### **Tag & Release Creation**
-- If event is *not* `pull_request`, we:
-  1. Create an annotated tag → `vX.Y.Z-etc.`
-  2. Push the tag to origin.
-  3. Create a GitHub release. If the version is alpha/beta/rc, set `prerelease: true`.  
-  4. If `ATTACH_ARTIFACTS_TO_RELEASE == true`, attach the `.vip` to the release using `Invoke-RestMethod`.
+<a name="artifact-upload-only"></a>
+### **Artifact Upload Only**
+- Uploads the `.vip` as an ephemeral artifact with `actions/upload-artifact@v4`.
+- The workflow does not create tags or GitHub releases; use a separate workflow if publishing is required.
 
 
 <a name="multiple-pre-release-channels-explained"></a>

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -22,7 +22,7 @@ This document details how to automate **building**, **testing**, and **packaging
 - **Eliminate** manual tasks like editing `vi.lib` or toggling `labview.ini`.  
 - **Run** consistent builds and tests across different machines or developers.  
 - **Automatically version** your Icon Editor code via **semantic labeling** (major/minor/patch) plus a global build counter.
-- **Upload** the `.vip` artifact for download, and (if configured) attach it to a draft GitHub Release for non-PR builds.
+- **Upload** the `.vip` artifact for download; the workflow does **not** create tags or GitHub releases.
 - Seamlessly handle **fork** scenarios—**GPG signing** is enabled if `github.repository` is your main repo, disabled otherwise.
 
 Additionally, **you can pass metadata fields** (like **organization** or **repository name**) to the **build script**. These fields are embedded into the **VI Package** display information, effectively **branding** the Icon Editor package with a unique identifier. This is especially useful when multiple forks or organizations produce their own versions of the Icon Editor—ensuring each `.vip` is clearly labeled with the correct “author” or “company.”
@@ -56,8 +56,8 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
 5. **Run Tests**
    - Run the tests using the main **Build VI Package** CI workflow (it will execute the unit tests).
 
-6. **Build VI Package**  
-   - Invoke **Build VI Package & Release** to produce `.vip`, automatically version your code (labels vs. default patch), and optionally create a GitHub Release.  
+6. **Build VI Package**
+   - Invoke **Build VI Package** to produce a `.vip` and automatically version your code (labels vs. default patch). Publishing tags or GitHub releases requires a separate workflow.
    - **You can also** pass in **org/repository** info (e.g., `-CompanyName "MyOrg"` or `-AuthorName "myorg/myrepo"`) to brand the resulting package with your unique identifiers.
 
 7. **Disable Dev Mode** (Optional)  
@@ -87,12 +87,12 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - `mode: disable` → calls `RevertDevelopmentMode.ps1`.  
    - Great for reconfiguring LabVIEW for local dev vs. distribution builds.
 
-2. **Build VI Package & Release**
+2. **Build VI Package**
    - Runs the unit tests and, on success, builds the `.vip`.
    - **Label-based** semantic versioning (`major`, `minor`, `patch`). Defaults to `patch` if no label.
    - **Counts existing tags** (`v*.*.*-build*`) to increment the global build number.
    - **Fork-friendly** GPG: disabled for forks to avoid passphrase prompts.
-   - Publishes `.vip` as an artifact and optionally creates a GitHub Release if not a pull request.
+   - Publishes `.vip` as an artifact; creating Git tags or GitHub releases requires a separate workflow.
    - **Branding the Package**:
      - You can **pass** metadata parameters like `-CompanyName` and `-AuthorName` into the build script. These map to fields in the **VI Package** (e.g., “Company Name,” “Author Name (Person or Company)”).
      - This means each package can show the **organization** and **repository** that produced it, providing a **unique ID** if you have multiple forks or parallel versions.
@@ -115,7 +115,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - Follow GitHub’s CLI instructions.
 
 4. **Labels** (optional)  
-   - If the workflow references `runs-on: [self-hosted, iconeditor]`, label your runner accordingly or update the YAML’s `runs-on` lines.
+   - The workflow uses labels like `self-hosted-windows-lv` (and `self-hosted-linux-lv` for Linux jobs). Label your runner accordingly or update the YAML’s `runs-on` lines.
 
 
 <a name="running-the-actions-locally"></a>
@@ -127,30 +127,30 @@ With your runner online:
    - **Actions → Development Mode Toggle**, set `mode: enable`.
 
 2. **Run Tests via Build VI Package**
-   - Execute **Build VI Package & Release** to run the unit tests; review the logs to confirm everything passes.
+   - Execute **Build VI Package** to run the unit tests; review the logs to confirm everything passes.
 
-3. **Build VI Package & Release**  
-   - Produces `.vip`, bumps the version, and can create a Git tag + GitHub Release (if not a PR).  
-   - **Pass** your **org/repo** info (e.g. `-CompanyName "AcmeCorp"` / `-AuthorName "AcmeCorp/IconEditor"`) to embed in the final package.  
+3. **Build VI Package**
+   - Produces `.vip` and bumps the version. The workflow only uploads the artifact; creating tags or GitHub releases requires additional steps.
+   - **Pass** your **org/repo** info (e.g. `-CompanyName "AcmeCorp"` / `-AuthorName "AcmeCorp/IconEditor"`) to embed in the final package.
    - Artifacts appear in the run summary under **Artifacts**.
 
 4. **Disable Dev Mode** (if used)  
    - `mode: disable` reverts your LabVIEW environment.
 
-5. **Review the `.vip`**  
-   - Download from **Artifacts** or check your Release page if a release was created.
+5. **Review the `.vip`**
+   - Download from **Artifacts**. Publishing to a GitHub release requires a separate workflow.
 
 
 <a name="example-developer-workflow"></a>
 ### 5. Example Developer Workflow
 
 1. **Enable Development Mode**: if you plan to actively modify the Icon Editor code inside LabVIEW.  
-2. **Code & Test**: Make changes, run the **Build VI Package & Release** workflow (which runs unit tests) to confirm stability.
+2. **Code & Test**: Make changes, run the **Build VI Package** workflow (which runs unit tests) to confirm stability.
 3. **Open a Pull Request**:  
    - Assign a version bump label if you want `major`, `minor`, or `patch`.  
    - The workflow checks this label upon merging.  
-4. **Merge**:  
-   - **Build VI Package & Release** triggers, incrementing version and uploading `.vip`.  
+4. **Merge**:
+   - **Build VI Package** triggers, incrementing version and uploading `.vip`.
    - **Metadata** (such as company/repo) is already integrated into the final `.vip`, so each build is easily identified.  
 5. **Disable Dev Mode**: Return to a normal LabVIEW environment.  
 6. **Install & Verify**: Download the `.vip` artifact for final validations.

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -110,7 +110,7 @@ For **detailed runner configuration**, see **`runner-setup-guide.md`**. Below is
 2. **Add a Self-Hosted Runner**  
    - Go to **Settings → Actions → Runners**. Follow GitHub’s steps to register a Windows runner on your machine with LabVIEW installed.  
 3. **Label Your Runner**  
-   - For example, `self-hosted, iconeditor`. Ensure your workflow’s `runs-on` references these labels.
+   - For example, use `self-hosted-windows-lv` (or `self-hosted-linux-lv` for Linux). Ensure your workflow’s `runs-on` references these labels.
 
 ---
 
@@ -142,7 +142,7 @@ You’ll typically name the workflow file **`development-mode-toggle.yml`**. Its
 1. **Trigger Manually**  
    - Go to the **Actions** tab, select the “Development Mode Toggle” workflow, click “Run workflow.”  
    - Choose `enable` or `disable` to run the corresponding PowerShell script (`Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`).  
-   - The workflow runs on your self-hosted runner (e.g., labeled `self-hosted, iconeditor`).
+   - The workflow runs on your self-hosted runner (e.g., labeled `self-hosted-windows-lv`).
 
 2. **Important Note for Testing**  
    - With dev mode **enabled**, LabVIEW references local code, so installing the `.vip` may fail or cause conflicts.  
@@ -163,7 +163,7 @@ on:
 
 jobs:
   call-dev-mode:
-    runs-on: [self-hosted, iconeditor]
+  runs-on: self-hosted-windows-lv
     steps:
       - name: Invoke Dev Mode Toggle (enable)
         uses: ./.github/workflows/development-mode-toggle.yml
@@ -179,7 +179,7 @@ on:
 
 jobs:
   remote-dev-mode:
-    runs-on: [self-hosted, iconeditor]
+  runs-on: self-hosted-windows-lv
     steps:
       - name: Use remote Dev Mode Toggle
         uses: <owner>/<repo>/.github/workflows/development-mode-toggle.yml@main
@@ -195,7 +195,7 @@ on:
 
 jobs:
   forked-workflow-call:
-    runs-on: [self-hosted, iconeditor]
+  runs-on: self-hosted-windows-lv
     steps:
       - name: Call Dev Mode Toggle from My Fork
         uses: <your-fork>/<repo>/.github/workflows/development-mode-toggle.yml@my-feature-branch


### PR DESCRIPTION
## Summary
- document the correct `self-hosted-windows-lv`/`self-hosted-linux-lv` runner labels
- clarify that CI builds artifacts but does not tag or create releases
- refresh example GitHub Action versions and note issue-status gating

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893ecd48e3883298911bf2c9ffdddc3