### PR TITLE
docs: clarify CI workflow naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ All interactions should be respectful and follow our [Code of Conduct](CODE_OF_C
    - **Issue Reference** – Link the issue number if one exists.
    - **Testing** – How can reviewers test or reproduce the change?
 8. **Respond to Feedback:** Maintainers will review your PR. You may see comments requesting changes or asking questions. This is a normal part of the process. Update your code as needed and push new commits; they will automatically be added to the PR.
-9. **CI Builds:** When you open a PR, our continuous integration will automatically attempt to build the VI Package and run tests. You’ll see a check for the **Build VI Package** workflow – if it fails, inspect the logs (e.g., missing dependencies or failing tests) and update your code. Successful CI will produce a `.vip` artifact that maintainers and you can download to test your changes in LabVIEW.
+9. **CI Builds:** When you open a PR, our continuous integration will automatically attempt to build the VI Package and run tests. You’ll see a check for the **CI Pipeline (Composite)** workflow with a job named **Build VI Package** – if it fails, inspect the logs (e.g., missing dependencies or failing tests) and update your code. Successful CI will produce a `.vip` artifact that maintainers and you can download to test your changes in LabVIEW.
 
 > Note: When opening a PR, apply exactly one release label (major, minor, or patch) to request the version bump. The CI pipeline will fail if no label (or multiple labels) are set, since it relies on a single label to determine the new version.
 

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -53,10 +53,10 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - (Optional) Toggle LabVIEW dev mode (`Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`) via the **Development Mode Toggle** workflow.
 
 5. **Run Tests**
-   - Run the tests using the main **Build VI Package** CI workflow (it will execute the unit tests).
+   - Run the tests using the **CI Pipeline (Composite)** workflow; its **Build VI Package** job executes the unit tests.
 
 6. **Build VI Package**
-   - Invoke **Build VI Package** to produce a `.vip` and automatically version your code (labels vs. default patch). Publishing tags or GitHub releases requires a separate workflow.
+   - Invoke the **Build VI Package** job within the CI Pipeline (Composite) workflow to produce a `.vip` and automatically version your code (labels vs. default patch). Publishing tags or GitHub releases requires a separate workflow.
    - **You can also** pass in **org/repository** info (e.g., `-CompanyName "MyOrg"` or `-AuthorName "myorg/myrepo"`) to brand the resulting package with your unique identifiers.
 
 7. **Disable Dev Mode** (Optional)  
@@ -86,8 +86,8 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - `mode: disable` → calls `RevertDevelopmentMode.ps1`.  
    - Great for reconfiguring LabVIEW for local dev vs. distribution builds.
 
-2. **Build VI Package**
-   - Runs the unit tests and, on success, builds the `.vip`.
+2. **CI Pipeline (Composite)**
+   - Contains the **Build VI Package** job, which runs unit tests and, on success, builds the `.vip`.
    - **Label-based** semantic versioning (`major`, `minor`, `patch`). Defaults to `patch` if no label.
    - **Counts existing tags** (`v*.*.*-build*`) to increment the global build number.
    - **Fork-friendly**: runs on forks without requiring signing keys.
@@ -122,14 +122,14 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
 
 With your runner online:
 
-1. **Enable Dev Mode** (if needed)  
+1. **Enable Dev Mode** (if needed)
    - **Actions → Development Mode Toggle**, set `mode: enable`.
 
-2. **Run Tests via Build VI Package**
-   - Execute **Build VI Package** to run the unit tests; review the logs to confirm everything passes.
+2. **Run Tests via CI Pipeline (Composite)**
+   - Execute the workflow and review the **Build VI Package** job logs to confirm all unit tests pass.
 
 3. **Build VI Package**
-   - Produces `.vip` and bumps the version. The workflow only uploads the artifact; creating tags or GitHub releases requires additional steps.
+   - Produces `.vip` and bumps the version through the Build VI Package job. The workflow only uploads the artifact; creating tags or GitHub releases requires additional steps.
    - **Pass** your **org/repo** info (e.g. `-CompanyName "AcmeCorp"` / `-AuthorName "AcmeCorp/IconEditor"`) to embed in the final package.
    - Artifacts appear in the run summary under **Artifacts**.
 
@@ -144,12 +144,12 @@ With your runner online:
 ### 5. Example Developer Workflow
 
 1. **Enable Development Mode**: if you plan to actively modify the Icon Editor code inside LabVIEW.  
-2. **Code & Test**: Make changes, run the **Build VI Package** workflow (which runs unit tests) to confirm stability.
+2. **Code & Test**: Make changes, run the **CI Pipeline (Composite)** workflow (its **Build VI Package** job runs unit tests) to confirm stability.
 3. **Open a Pull Request**:  
    - Assign a version bump label if you want `major`, `minor`, or `patch`.  
    - The workflow checks this label upon merging.  
 4. **Merge**:
-   - **Build VI Package** triggers, incrementing version and uploading `.vip`.
+   - The **CI Pipeline (Composite)** workflow triggers, and its **Build VI Package** job increments the version and uploads the `.vip`.
    - **Metadata** (such as company/repo) is already integrated into the final `.vip`, so each build is easily identified.  
 5. **Disable Dev Mode**: Return to a normal LabVIEW environment.  
 6. **Install & Verify**: Download the `.vip` artifact for final validations.

--- a/docs/ci/troubleshooting-faq.md
+++ b/docs/ci/troubleshooting-faq.md
@@ -88,7 +88,7 @@ Below are 13 possible issues you might encounter, along with suggested steps to 
 **Solution**:
 1. Make sure the label is exactly `major`, `minor`, or `patch` in lowercase (unless your workflow script also checks for capitalized labels).  
 2. Confirm you’re actually using a Pull Request event (not a direct push).  
-3. Check logs for “Determining Bump Type” in the Build VI Package workflow.
+3. Check the CI Pipeline (Composite) logs for the **version** job’s “Determine bump type” step (from `.github/actions/compute-version`).
 
 ---
 

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -10,7 +10,7 @@ This guide explains how to automate build, test, and distribution steps for the 
 ## Table of Contents
 
 1. [Introduction](#1-introduction)  
-2. [Quickstart / Step-by-Step Procedure](#2-quickstart--step-by-step-procedure)  
+2. [Quickstart / Step-by-Step Procedure](#2-quickstart--step-by-step-procedure)
 3. [Getting Started and Configuration](#3-getting-started--configuration)
    1. [Development Mode](#31-development-mode)
    2. [Self-Hosted Runner Setup](#32-self-hosted-runner-setup)
@@ -21,7 +21,7 @@ This guide explains how to automate build, test, and distribution steps for the 
        - [Examples: Calling This Workflow](#413-examples-calling-this-workflow)
        - [Customization](#414-customization)
        - [Additional Resources](#415-additional-resources)
-   2. [Build VI Package](#42-build-vi-package)
+   2. [CI Pipeline (Composite)](#42-ci-pipeline-composite)
 5. [Gitflow Branching and Versioning](#5-gitflow-branching--versioning)
    1. [Branching Overview](#51-branching-overview)
    2. [Multi-Channel Pre-Releases](#52-multi-channel-pre-releases)  
@@ -55,7 +55,7 @@ This workflow ensures that all **forks** of the repository can sync the latest b
 1. **Set up `.github/workflows`**
    Ensure the following workflows exist (or adapt names as needed):
    - `development-mode-toggle.yml` (Development Mode Toggle)
-   - `ci-composite.yml` (Build VI Package)
+   - `ci-composite.yml` (CI Pipeline (Composite); includes the **Build VI Package** job)
 
 2. **Configure Permissions**
    - In **Settings → Actions → General**, set **Workflow permissions** to allow the workflow to read repository contents and upload artifacts.
@@ -219,11 +219,11 @@ All dev-mode logic resides in two PowerShell scripts:
 
 ---
 
-<a name="42-build-vi-package"></a>
-### 4.2 Build VI Package
+<a name="42-ci-pipeline-composite"></a>
+### 4.2 CI Pipeline (Composite)
 
 - **File Name**: `ci-composite.yml`
-- **Purpose**: Builds the `.vip` artifact and determines the version based on PR labels and commit count.
+- **Purpose**: The workflow's **Build VI Package** job builds the `.vip` artifact and determines the version based on PR labels and commit count.
 - **Features**:
     - **Issue status gating**: skips most jobs unless the branch's linked issue has Status **In Progress**.
     - **Label-based** version bump (`major`, `minor`, `patch`), or none if unlabeled.
@@ -292,7 +292,7 @@ When you open a **Pull Request** into `develop`, `release-alpha/*`, or `release-
 In order to **enforce** the Gitflow approach “hands-off”:
 1. **Enable Branch Protection Rules**:  
    - For example, protect `main`, `release-alpha/*`, `release-beta/*`, and `release-rc/*` so that only approved Pull Requests can be merged, preventing direct pushes.  
-   - Require checks (like “Build VI Package”) to pass before merging.
+   - Require the **Build VI Package** job from the CI Pipeline (Composite) workflow to pass before merging.
 2. **Refer to `CONTRIBUTING.md`**:  
    - Document your team’s policies on how merges flow from feature → develop → alpha/beta/rc → main.  
    - Outline any required approvals or code reviews.  


### PR DESCRIPTION
## Summary
- reference the CI Pipeline (Composite) workflow and its Build VI Package job in CONTRIBUTING
- clarify where to find bump-type logs in the version job
- rename Build VI Package workflow references across CI docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893f4249b48832988ebe047dd7746a0