### PR TITLE
docs: clarify CI composites and workflow references

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -48,7 +48,7 @@ Automating your Icon Editor builds and tests:
 4. **Run Tests**
    Use the main CI workflow (`ci-composite.yml`) to confirm your environment is valid.
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-   - CI jobs proceed only when your branch is named `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. See the [`issue-status` job](../.github/workflows/ci-composite.yml#L39) for details.
+   - CI jobs proceed only when your branch is named `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. See the `issue-status` job in [ci-composite.yml](../.github/workflows/ci-composite.yml) for details.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically, **including** optional metadata fields (`-CompanyName`, `-AuthorName`) that let you **brand** your package.

--- a/docs/ci/actions/README.md
+++ b/docs/ci/actions/README.md
@@ -10,6 +10,8 @@ This repository defines several reusable [composite actions](https://docs.github
 | [build-lvlibp](../../../.github/actions/build-lvlibp) | Creates the editor packed library. |
 | [build-vi-package](../../../.github/actions/build-vi-package) | Updates a VIPB file and builds the VI package. |
 | [close-labview](../../../.github/actions/close-labview) | Gracefully shuts down a LabVIEW instance. |
+| [compute-version](../../../.github/actions/compute-version) | Determines the semantic version from commit history and labels. |
+| [generate-release-notes](../../../.github/actions/generate-release-notes) | Generates Markdown release notes from recent commits. |
 | [missing-in-project](../../../.github/actions/missing-in-project) | Checks a project for missing files using `MissingInProjectCLI.vi`. |
 | [modify-vipb-display-info](../../../.github/actions/modify-vipb-display-info) | Updates display information in a VIPB file. |
 | [prepare-labview-source](../../../.github/actions/prepare-labview-source) | Prepares LabVIEW sources for builds. |

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -93,9 +93,8 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 ## 3. **Action Configuration & Usage**
 
 ### 3.1 How the Action Is Triggered
-- **push**: On branches `main`, `develop`, `release-alpha/*`, `release-beta/*`, `release-rc/*`, `feature/*`, `hotfix/*`.
-- **pull_request**: For PRs into those branches, so you can detect version labels.
-- **workflow_dispatch**: Maintainers can manually run from the Actions tab if needed (e.g., for a hotfix you want to rebuild).
+The `build-vi-package` directory defines a **composite action**. It does not listen for events on its own; instead, the CI workflow in [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) invokes it.
+That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events, so this action executes whenever the workflow is triggered.
 
 ### 3.2 Configurable Inputs / Parameters
 - **PR Labels**: `major`, `minor`, `patch`, or none. If none, only the build number changes.
@@ -244,9 +243,10 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 ### 8.3 LabVIEW-Specific QA
 - If you have LabVIEW unit tests, integrate them by adding a step in the YAML:
   ```yaml
-  - name: Run LabVIEW Tests
-    shell: pwsh
-    run: .\.github\actions\run-unit-tests\RunUnitTests.ps1
+  - uses: ./.github/actions/run-unit-tests
+    with:
+      minimum_supported_lv_version: ${{ matrix['lv-version'] }}
+      supported_bitness:            ${{ matrix.bitness }}
   ```
 - Ensure they pass before building the `.vip`. If they fail, the script can exit with a non-zero code, stopping the workflow run.
 


### PR DESCRIPTION
## Summary
- document missing `compute-version` and `generate-release-notes` composite actions
- replace fragile line-number link to `issue-status` job with stable reference
- clarify that `build-vi-package` triggers come from the workflow and update QA example to use `run-unit-tests`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893f776c70c8329883117a4ac0c4bb2