### PR TITLE
doc: clarify CI pipeline responsibilities

### DIFF
--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -53,10 +53,10 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - (Optional) Toggle LabVIEW dev mode (`Set_Development_Mode.ps1` or `RevertDevelopmentMode.ps1`) via the **Development Mode Toggle** workflow.
 
 5. **Run Tests**
-   - Run the tests using the **CI Pipeline (Composite)** workflow; its **Build VI Package** job executes the unit tests.
+   - Run the tests using the **CI Pipeline (Composite)** workflow; its dedicated **test** job executes the unit tests.
 
 6. **Build VI Package**
-   - Invoke the **Build VI Package** job within the CI Pipeline (Composite) workflow to produce a `.vip` and automatically version your code (labels vs. default patch). Publishing tags or GitHub releases requires a separate workflow.
+   - Invoke the **Build VI Package** job within the CI Pipeline (Composite) workflow to produce a `.vip` using the version computed by the workflow's separate **version** job (see that job's output for the generated version). Publishing tags or GitHub releases requires a separate workflow.
    - **You can also** pass in **org/repository** info (e.g., `-CompanyName "MyOrg"` or `-AuthorName "myorg/myrepo"`) to brand the resulting package with your unique identifiers.
 
 7. **Disable Dev Mode** (Optional)  
@@ -87,7 +87,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - Great for reconfiguring LabVIEW for local dev vs. distribution builds.
 
 2. **CI Pipeline (Composite)**
-   - Contains the **Build VI Package** job, which runs unit tests and, on success, builds the `.vip`.
+   - Includes a **test** job for unit tests, a **version** job that computes semantic versioning, and a **build-vi-package** job that packages the `.vip` using the version job's outputs.
    - **Label-based** semantic versioning (`major`, `minor`, `patch`). Defaults to `patch` if no label.
    - **Counts existing tags** (`v*.*.*-build*`) to increment the global build number.
    - **Fork-friendly**: runs on forks without requiring signing keys.
@@ -113,8 +113,8 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - **Settings → Actions → Runners** → **New self-hosted runner**  
    - Follow GitHub’s CLI instructions.
 
-4. **Labels** (optional)  
-   - The workflow uses labels like `self-hosted-windows-lv` (and `self-hosted-linux-lv` for Linux jobs). Label your runner accordingly or update the YAML’s `runs-on` lines.
+4. **Labels** (optional)
+   - The workflow uses the `self-hosted-windows-lv` label. A Linux label (`self-hosted-linux-lv`) is reserved for future jobs but is not currently used in `ci-composite.yml`. Label your runner accordingly or update the YAML’s `runs-on` lines.
 
 
 <a name="running-the-actions-locally"></a>
@@ -126,10 +126,10 @@ With your runner online:
    - **Actions → Development Mode Toggle**, set `mode: enable`.
 
 2. **Run Tests via CI Pipeline (Composite)**
-   - Execute the workflow and review the **Build VI Package** job logs to confirm all unit tests pass.
+   - Execute the workflow and review the **test** job logs to confirm all unit tests pass.
 
 3. **Build VI Package**
-   - Produces `.vip` and bumps the version through the Build VI Package job. The workflow only uploads the artifact; creating tags or GitHub releases requires additional steps.
+   - Produces `.vip` using the version computed in the **version** job (review that job's output for version details). The workflow only uploads the artifact; creating tags or GitHub releases requires additional steps.
    - **Pass** your **org/repo** info (e.g. `-CompanyName "AcmeCorp"` / `-AuthorName "AcmeCorp/IconEditor"`) to embed in the final package.
    - Artifacts appear in the run summary under **Artifacts**.
 
@@ -144,13 +144,13 @@ With your runner online:
 ### 5. Example Developer Workflow
 
 1. **Enable Development Mode**: if you plan to actively modify the Icon Editor code inside LabVIEW.  
-2. **Code & Test**: Make changes, run the **CI Pipeline (Composite)** workflow (its **Build VI Package** job runs unit tests) to confirm stability.
+2. **Code & Test**: Make changes, run the **CI Pipeline (Composite)** workflow (its **test** job runs unit tests) to confirm stability.
 3. **Open a Pull Request**:  
    - Assign a version bump label if you want `major`, `minor`, or `patch`.  
    - The workflow checks this label upon merging.  
 4. **Merge**:
-   - The **CI Pipeline (Composite)** workflow triggers, and its **Build VI Package** job increments the version and uploads the `.vip`.
-   - **Metadata** (such as company/repo) is already integrated into the final `.vip`, so each build is easily identified.  
+   - The **CI Pipeline (Composite)** workflow triggers, with the **version** job computing the version and the **Build VI Package** job using that version to package and upload the `.vip`.
+   - **Metadata** (such as company/repo) is already integrated into the final `.vip`, so each build is easily identified.
 5. **Disable Dev Mode**: Return to a normal LabVIEW environment.  
 6. **Install & Verify**: Download the `.vip` artifact for final validations.
 

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -222,8 +222,8 @@ All dev-mode logic resides in two PowerShell scripts:
 <a name="42-ci-pipeline-composite"></a>
 ### 4.2 CI Pipeline (Composite)
 
-- **File Name**: `ci-composite.yml`
-- **Purpose**: The workflow's **Build VI Package** job builds the `.vip` artifact and determines the version based on PR labels and commit count.
+ - **File Name**: `ci-composite.yml`
+ - **Purpose**: A dedicated **version** job (using `compute-version`) derives the version from PR labels and commit count, and the **Build VI Package** job builds the `.vip` artifact using that version output.
 - **Features**:
     - **Issue status gating**: skips most jobs unless the branch's linked issue has Status **In Progress**.
     - **Label-based** version bump (`major`, `minor`, `patch`), or none if unlabeled.


### PR DESCRIPTION
## Summary
- clarify that unit tests run in a dedicated `test` job and versioning happens in the `version` job
- remove misleading Linux runner label instructions
- note that `compute-version` drives versioning in CI pipeline docs

## Testing
- `npx -y markdownlint-cli --config /tmp/md-config.json docs/ci/actions/runner-setup-guide.md docs/powershell-cli-github-action-instructions.md`


------
https://chatgpt.com/codex/tasks/task_e_6893fa6b5814832980290ede73968219