### PR TITLE
docs: clarify composite actions and inputs

### DIFF
--- a/docs/ci/actions/README.md
+++ b/docs/ci/actions/README.md
@@ -20,6 +20,5 @@ This repository defines several reusable [composite actions](https://docs.github
 | [revert-development-mode](../../../.github/actions/revert-development-mode) | Restores the repository after development mode. |
 | [run-unit-tests](../../../.github/actions/run-unit-tests) | Executes LabVIEW unit tests via g-cli. |
 | [set-development-mode](../../../.github/actions/set-development-mode) | Configures the repository for development mode. |
-| [unit-tests](../../../.github/actions/unit-tests) | Prepares and executes LabVIEW unit tests. |
 
 Each action directory includes a `README.md` and `action.yml` with full usage details.

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -97,7 +97,28 @@ The `build-vi-package` directory defines a **composite action**. It does not lis
 That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events, so this action executes whenever the workflow is triggered.
 
 ### 3.2 Configurable Inputs / Parameters
-- **PR Labels**: `major`, `minor`, `patch`, or none. If none, only the build number changes.
+`ci-composite.yml` calls this action and provides all required inputs automatically. When invoking
+`build-vi-package` from another workflow, supply the following parameters
+(see [action.yml](../../../.github/actions/build-vi-package/action.yml) for details):
+
+| Input | Description |
+| --- | --- |
+| `supported_bitness` | `32` or `64`; selects the VI Package bitness. |
+| `relative_path` | Workspace root path. |
+| `vipb_path` | Path to the `.vipb` file relative to the workspace. |
+| `minimum_supported_lv_version` | LabVIEW major version. |
+| `labview_minor_revision` | LabVIEW minor revision (defaults to `3`). |
+| `major` | Major version component. |
+| `minor` | Minor version component. |
+| `patch` | Patch version component. |
+| `build` | Build number. |
+| `commit` | Commit identifier. |
+| `release_notes_file` | Path to release notes file. |
+| `display_information_json` | DisplayInformation JSON string. |
+
+The `major`, `minor`, and `patch` inputs are derived from pull-request labels (`major`,
+`minor`, `patch`) by the `compute-version` job in `ci-composite.yml`. If no label is present,
+only the build number changes.
 
 ### 3.3 Customization & Fork Setup
 - **Fork Setup**:
@@ -116,7 +137,7 @@ That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events, so
 ### 4.1 Pipeline Overview
 
 1. **Check Out & Full Clone**
-   - Uses `actions/checkout@v4` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
+   - Uses `actions/checkout@v3` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
 
 2. **Determine Bump Type**
    - On PR events, scans the PR labels: `major`, `minor`, `patch`, or defaults to `none`.  
@@ -174,7 +195,7 @@ That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events, so
 
 ### 6.1 Keeping the Workflow Updated
 1. **Actions Versions**
-   - This workflow references certain actions, like `actions/checkout@v4` or `actions/github-script@v7`. Keep an eye on updates or deprecations.
+   - This workflow references certain actions, like `actions/checkout@v3` or `actions/github-script@v7`. Keep an eye on updates or deprecations. Update to a newer checkout version when the action itself is revised.
 2. **Build Actions**
    - If your LabVIEW project evolves or you add steps, keep the `build-lvlibp` and `build-vi-package` actions up to date.
 3. **Windows Runner Updates**  

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -71,11 +71,11 @@ This workflow ensures that all **forks** of the repository can sync the latest b
      - and finally **main** for a final release (no suffix).  
    - Alternatively, **`hotfix/*`** merges can go directly to **main** for quick patches.
 
-6. **Check Build Artifacts**
+5. **Check Build Artifacts**
    - The `.vip` file is generated and uploaded as a build artifact.
    - If you want to publish a GitHub Release, create one manually and upload the artifact.
 
-7. **Optionally Enable Development Mode**
+6. **Optionally Enable Development Mode**
    - If you need LabVIEW to reference local source directly, run the **Development Mode Toggle** workflow (see [Development Mode](#31-development-mode)). Usually, you **disable** it for standard builds/tests.
 
 For a visual reference, you may consult a **Gitflow diagram** that includes alpha/beta/rc branches as an extension of the typical `release/` branch. This helps illustrate how merges flow between `develop` and `main`.


### PR DESCRIPTION
## Summary
- remove unused `unit-tests` action entry
- document required inputs for build-vi-package action
- fix checkout version and quickstart numbering

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893fdc61ba48329b9e184c12829145c