### PR TITLE
docs: clarify CI build number and gating

### DIFF
--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -94,7 +94,10 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 
 ### 3.1 How the Action Is Triggered
 The `build-vi-package` directory defines a **composite action**. It does not listen for events on its own; instead, the CI workflow in [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) invokes it.
-That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events, so this action executes whenever the workflow is triggered.
+That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events,
+but `build-vi-package` executes only if the `issue-status` job allows the
+pipeline to continue because its dependencies (`version` and `build-ppl`)
+require that gate.
 
 ### 3.2 Configurable Inputs / Parameters
 `ci-composite.yml` calls this action and provides all required inputs automatically. When invoking

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -89,7 +89,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
 2. **CI Pipeline (Composite)**
    - Includes a **test** job for unit tests, a **version** job that computes semantic versioning, and a **build-vi-package** job that packages the `.vip` using the version job's outputs.
    - **Label-based** semantic versioning (`major`, `minor`, `patch`). Defaults to `patch` if no label.
-   - **Counts existing tags** (`v*.*.*-build*`) to increment the global build number.
+   - **Derives build number from total commit count** (`git rev-list --count HEAD`).
    - **Fork-friendly**: runs on forks without requiring signing keys.
    - Publishes `.vip` as an artifact; creating Git tags or GitHub releases requires a separate workflow.
    - **Branding the Package**:


### PR DESCRIPTION
## Summary
- clarify build-number computation in runner setup guide
- note issue-status gating for build-vi-package action

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68940152e9c88329abf02026a4d66881