### PR TITLE
docs: clarify conditional apply-deps and runner labels

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -98,7 +98,7 @@ The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks 
 
 - **issue-status** – ensures CI runs only on branches named `issue-<number>` whose linked GitHub issue has Status “In Progress”.
 - **changes** – checks out the repository and detects `.vipc` file changes to determine if dependencies need to be applied.
-- **apply-deps** – installs VIPC dependencies for multiple LabVIEW versions and bitnesses.
+- **apply-deps** – installs VIPC dependencies for multiple LabVIEW versions and bitnesses **only when** the `changes` job reports `.vipc` modifications (`if: needs.changes.outputs.vipc == 'true'`).
 - **version** – computes the semantic version and build number using commit count and PR labels.
 - **missing-in-project-check** – verifies every source file is referenced in the `.lvproj`.
 - **test** – runs LabVIEW unit tests across the supported matrix.

--- a/docs/ci/actions/runner-setup-guide.md
+++ b/docs/ci/actions/runner-setup-guide.md
@@ -44,6 +44,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
 
 2. **Apply the VIPC (optional)**
    - Apply `Tooling/deployment/runner_dependencies.vipc` with VIPM in **LabVIEW 2021 (32-bit)**; repeat for **LabVIEW 2021 (64-bit)**. If using **LabVIEW 2023 (64-bit)** for builds, apply the same VIPC there as well.
+   - The CI workflow's `apply-deps` job installs these dependencies only when `.vipc` files change (`if: needs.changes.outputs.vipc == 'true'`). On a fresh runner or when no `.vipc` changes are present, apply the VIPC manually.
 
 3. **Configure a Self-Hosted Runner**  
    - Go to **Settings → Actions → Runners** in your (forked) repo.  
@@ -114,7 +115,7 @@ Additionally, **you can pass metadata fields** (like **organization** or **repos
    - Follow GitHub’s CLI instructions.
 
 4. **Labels** (optional)
-   - The workflow uses the `self-hosted-windows-lv` label. A Linux label (`self-hosted-linux-lv`) is reserved for future jobs but is not currently used in `ci-composite.yml`. Label your runner accordingly or update the YAML’s `runs-on` lines.
+   - The workflow uses the `self-hosted-windows-lv` label. Its `runs-on` expression also references `self-hosted-linux-lv` for potential Linux jobs, though the default matrix runs only on Windows. Label your runner accordingly, and prepare a Linux runner with `self-hosted-linux-lv` if you expand the matrix.
 
 
 <a name="running-the-actions-locally"></a>


### PR DESCRIPTION
## Summary
- clarify that the `apply-deps` CI job runs only when `.vipc` files change
- document manual VIPC application on new runners and note Linux runner label usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689404fe9de88329a8f9db75221cc223