### PR TITLE
docs: clarify CI workflow branch gating

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -47,8 +47,9 @@ Automating your Icon Editor builds and tests:
 
 4. **Run Tests**
    Use the main CI workflow (`ci-composite.yml`) to confirm your environment is valid.
+   - The workflow triggers on pushes or pull requests to `main`, `develop`, and release branches (for example, `release-*`, `feature/*`, and `hotfix/*`).
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-   - CI jobs proceed only when your branch is named `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. See the `issue-status` job in [ci-composite.yml](../.github/workflows/ci-composite.yml) for details.
+   - An `issue-status` job gates execution: it skips all other jobs unless the branch starts with `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. This gating helps avoid ambiguous runs for automated tools.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically, **including** optional metadata fields (`-CompanyName`, `-AuthorName`) that let you **brand** your package.


### PR DESCRIPTION
## Summary
- clarify CI Quickstart step on which branches trigger the workflow
- explain gating that limits full CI runs to `issue-*` branches linked to In Progress issues

## Testing
- `npx markdownlint-cli docs/ci-workflows.md --disable MD013 MD032`


------
https://chatgpt.com/codex/tasks/task_e_68940a6313e48329b6a008fc8aacb349