### PR TITLE
docs: update checkout version in build-vi-package guide

### DIFF
--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -140,7 +140,7 @@ only the build number changes.
 ### 4.1 Pipeline Overview
 
 1. **Check Out & Full Clone**
-   - Uses `actions/checkout@v3` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
+   - Uses `actions/checkout@v4` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
 
 2. **Determine Bump Type**
    - On PR events, scans the PR labels: `major`, `minor`, `patch`, or defaults to `none`.  


### PR DESCRIPTION
## Summary
- use `actions/checkout@v4` in the "Check Out & Full Clone" step of the build-vi-package docs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68940f2d423083298c5a830a69e2361e