### PR TITLE
docs: clarify CI branch triggers and issue gating

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -47,7 +47,12 @@ Automating your Icon Editor builds and tests:
 
 4. **Run Tests**
    Use the main CI workflow (`ci-composite.yml`) to confirm your environment is valid.
-   - The workflow triggers on pushes or pull requests to `main`, `develop`, and release branches (for example, `release-*`, `feature/*`, and `hotfix/*`).
+   - The workflow triggers on pushes or pull requests to:
+     - `main`
+     - `develop`
+     - release branches: `release-alpha/*`, `release-beta/*`, `release-rc/*`
+     - feature branches: `feature/*`
+     - hotfix branches: `hotfix/*`
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
    - An `issue-status` job gates execution: it skips all other jobs unless the branch starts with `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. This gating helps avoid ambiguous runs for automated tools.
 

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -96,7 +96,7 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 The `build-vi-package` directory defines a **composite action**. It does not listen for events on its own; instead, the CI workflow in [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) invokes it.
 That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events,
 but `build-vi-package` executes only if the `issue-status` job allows the
-pipeline to continue because its dependencies (`version` and `build-ppl`)
+pipeline to continue: the branch name must start with `issue-<number>` and the linked issue's Status must be **In Progress**, because its dependencies (`version` and `build-ppl`)
 require that gate.
 
 ### 3.2 Configurable Inputs / Parameters

--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -225,7 +225,7 @@ All dev-mode logic resides in two PowerShell scripts:
  - **File Name**: `ci-composite.yml`
  - **Purpose**: A dedicated **version** job (using `compute-version`) derives the version from PR labels and commit count, and the **Build VI Package** job builds the `.vip` artifact using that version output.
 - **Features**:
-    - **Issue status gating**: skips most jobs unless the branch's linked issue has Status **In Progress**.
+    - **Issue status gating**: skips most jobs unless the branch name starts with `issue-<number>` and the linked issue has Status **In Progress**.
     - **Label-based** version bump (`major`, `minor`, `patch`), or none if unlabeled.
     - **Commit-based build number**: `vX.Y.Z-build<commitCount>` (plus optional pre-release suffix).
     - **Multi-Channel** detection for `release-alpha/*`, `release-beta/*`, `release-rc/*`.


### PR DESCRIPTION
## Summary
- list release branch patterns in quickstart and separate feature/hotfix categories
- document that CI jobs require branches prefixed with `issue-`

## Testing
- `npx markdownlint-cli@0.39.0 docs/ci-workflows.md docs/powershell-cli-github-action-instructions.md docs/ci/actions/build-vi-package.md` *(fails: line-length and style warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689410fa76e483299b93c36e7a5d5556