### PR TITLE
Fix PR branch detection in CI workflow

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -52,7 +52,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const branch = context.ref.replace('refs/heads/', '');
+            const branch = context.payload.pull_request?.head.ref ??
+              context.ref.replace('refs/heads/', '');
             if (!branch.startsWith('issue-')) {
               core.setOutput('proceed', 'false');
               const msg = `Branch '${branch}' is not issue-specific. CI will be skipped.`;

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -47,14 +47,14 @@ Automating your Icon Editor builds and tests:
 
 4. **Run Tests**
    Use the main CI workflow (`ci-composite.yml`) to confirm your environment is valid.
-   - The workflow triggers on pushes or pull requests to:
+   - The workflow triggers on pushes to or pull requests targeting:
      - `main`
      - `develop`
      - release branches: `release-alpha/*`, `release-beta/*`, `release-rc/*`
      - feature branches: `feature/*`
      - hotfix branches: `hotfix/*`
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-   - An `issue-status` job gates execution: it skips all other jobs unless the branch starts with `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. This gating helps avoid ambiguous runs for automated tools.
+   - An `issue-status` job gates execution: it skips all other jobs unless the source branch starts with `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically. By default, the workflow populates the **“Company Name”** with `github.repository_owner` and the **“Author Name”** with `github.event.repository.name`, so each build is branded with your GitHub account and repository.
@@ -103,7 +103,7 @@ Below are the **key GitHub Actions** provided in this repository:
 
 The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks the build into several jobs:
 
-- **issue-status** – ensures CI runs only on branches named `issue-<number>` whose linked GitHub issue has Status “In Progress”.
+- **issue-status** – ensures CI runs only when the source branch is named `issue-<number>` and the linked GitHub issue has Status “In Progress”. For pull requests, the job evaluates the PR’s head branch.
 - **changes** – checks out the repository and detects `.vipc` file changes to determine if dependencies need to be applied.
 - **apply-deps** – installs VIPC dependencies for multiple LabVIEW versions and bitnesses **only when** the `changes` job reports `.vipc` modifications (`if: needs.changes.outputs.vipc == 'true'`).
 - **version** – computes the semantic version and build number using commit count and PR labels.

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -94,9 +94,7 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 
 ### 3.1 How the Action Is Triggered
 The `build-vi-package` directory defines a **composite action**. It does not listen for events on its own; instead, the CI workflow in [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) invokes it.
-That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events,
-but `build-vi-package` executes only if the `issue-status` job allows the
-pipeline to continue: the branch name must start with `issue-<number>` and the linked issue's Status must be **In Progress**, because its dependencies (`version` and `build-ppl`)
+That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. Pushes are limited to `main`, `develop`, `release-alpha/*`, `release-beta/*`, `release-rc/*`, `feature/*`, and `hotfix/*` branches, and pull requests must target one of those branches. However, `build-vi-package` executes only if the `issue-status` job allows the pipeline to continue: the source branch must start with `issue-<number>` and the linked issue's Status must be **In Progress**. For pull requests, the gate evaluates the PR’s head branch before proceeding, because its dependencies (`version` and `build-ppl`)
 require that gate.
 
 ### 3.2 Configurable Inputs / Parameters


### PR DESCRIPTION
## Summary
- check pull request head branch when verifying issue status
- document CI trigger conditions and branch requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894158017388329b6abf2d7c02364fc