### PR TITLE
docs: clarify checkout version in build package workflow

### DIFF
--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -196,7 +196,7 @@ only the build number changes.
 
 ### 6.1 Keeping the Workflow Updated
 1. **Actions Versions**
-   - This workflow references certain actions, like `actions/checkout@v3` or `actions/github-script@v7`. Keep an eye on updates or deprecations. Update to a newer checkout version when the action itself is revised.
+   - This workflow references certain actions, like `actions/checkout@v4` or `actions/github-script@v7`. Keep an eye on updates or deprecations. Update to a newer checkout version when the action itself is revised. Some internal actions—such as `compute-version`—may still pin older releases (e.g., `actions/checkout@v3`) for compatibility, so mixing versions is expected.
 2. **Build Actions**
    - If your LabVIEW project evolves or you add steps, keep the `build-lvlibp` and `build-vi-package` actions up to date.
 3. **Windows Runner Updates**  


### PR DESCRIPTION
## Summary
- reference checkout v4 in build-vi-package guide
- mention some internal actions like compute-version still use older action versions

## Testing
- `npx -y markdownlint-cli docs/ci/actions/build-vi-package.md` *(fails: many MD013 line-length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68941d04b2f883299d26a2741b739921