### PR TITLE
docs: clarify 64-bit packaging

### DIFF
--- a/docs/ci/actions/injecting-repo-org-to-vi-package.md
+++ b/docs/ci/actions/injecting-repo-org-to-vi-package.md
@@ -44,7 +44,7 @@ We achieve this by:
 
 ## GitHub Actions and PowerShell
 
-A typical **GitHub Actions** workflow might have steps like (showing only the 64-bit path for brevity):
+A typical **GitHub Actions** workflow might have steps like. The composite CI workflow packages only a **64-bit** VI package, so only the 64-bit path is shown:
 
 ```yaml
 jobs:
@@ -69,19 +69,20 @@ jobs:
       - uses: ./.github/actions/modify-vipb-display-info
         with:
           vipb_path: Tooling/deployment/NI Icon editor.vipb
+          minimum_supported_lv_version: 2021
+          labview_minor_revision: 3
           display_information_json: ${{ steps.display-info.outputs.json }}
           relative_path: ${{ github.workspace }}
           supported_bitness: 64
       - uses: ./.github/actions/build-vi-package
         with:
           vipb_path: Tooling/deployment/NI Icon editor.vipb
+          minimum_supported_lv_version: 2021
+          labview_minor_revision: 3
           display_information_json: ${{ steps.display-info.outputs.json }}
           relative_path: ${{ github.workspace }}
           supported_bitness: 64
 ```
-
-The real CI workflow repeats these steps for the 32-bit toolchain as well.
-
 **Key points**:
 - **`${{ github.repository_owner }}`** is the **organization** (or user) that owns the repo.
 - **`${{ github.event.repository.name }}`** is the repository name.
@@ -94,10 +95,10 @@ The real CI workflow repeats these steps for the 32-bit toolchain as well.
 1. **Developer** pushes code to GitHub.  
 2. **GitHub Actions** triggers the workflow.  
 3. **Actions** check out the repo and run the build actions:
-   1. `build-lvlibp` compiles the 32-bit and 64-bit libraries.
+   1. `build-lvlibp` compiles the 64-bit libraries.
    2. A PowerShell step generates JSON with `CompanyName` and `AuthorName` fields derived from GitHub variables.
    3. `modify-vipb-display-info` merges that JSON into the `.vipb` file.
-   4. `build-vi-package` produces the final **Icon Editor** `.vip` package.
+   4. `build-vi-package` produces the final 64-bit **Icon Editor** `.vip` package.
 4. **Actions** can then upload the resulting `.vip` as an artifact.
 
 ---


### PR DESCRIPTION
## Summary
- clarify that the composite CI workflow produces a 64-bit VI package
- document required `minimum_supported_lv_version` and `labview_minor_revision` inputs for relevant steps
- remove references to repeating steps for 32-bit

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68941fd34c1083298332718426be3f0c