### PR TITLE
docs: pin build-vi-package checkout to v3

### DIFF
--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -139,7 +139,7 @@ without labels, the version components remain unchanged and only the build numbe
 ### 4.1 Pipeline Overview
 
 1. **Check Out & Full Clone**
-   - Uses `actions/checkout@v4` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
+   - Uses `actions/checkout@v3` with `fetch-depth: 0` so we get the entire commit history (required for commit-based build number).
 
 2. **Determine Bump Type**
    - On PR events, scans the PR labels: `major`, `minor`, `patch`, or defaults to `none`.  
@@ -197,7 +197,7 @@ without labels, the version components remain unchanged and only the build numbe
 
 ### 6.1 Keeping the Workflow Updated
 1. **Actions Versions**
-   - This workflow references certain actions, like `actions/checkout@v4` or `actions/github-script@v7`. Keep an eye on updates or deprecations. Update to a newer checkout version when the action itself is revised. Some internal actions—such as `compute-version`—may still pin older releases (e.g., `actions/checkout@v3`) for compatibility, so mixing versions is expected.
+   - This workflow references certain actions, like `actions/checkout@v3` or `actions/github-script@v7`. Keep an eye on updates or deprecations. Update to a newer checkout version when the action itself is revised. Some internal actions—such as `compute-version`—may still pin different releases for compatibility, so mixing versions is expected.
 2. **Build Actions**
    - If your LabVIEW project evolves or you add steps, keep the `build-lvlibp` and `build-vi-package` actions up to date.
 3. **Windows Runner Updates**  


### PR DESCRIPTION
## Summary
- note that build-vi-package uses actions/checkout@v3
- align documentation with pinned checkout version

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689421d4ae548329a3535ebde138224a