### PR TITLE
Support issue branch patterns in CI workflow

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -18,6 +18,7 @@ on:
       - release-rc/*
       - feature/*
       - hotfix/*
+      - issue-*
   pull_request:
     branches:
       - main
@@ -27,6 +28,7 @@ on:
       - release-rc/*
       - feature/*
       - hotfix/*
+      - issue-*
     types:
       - opened
       - synchronize
@@ -54,7 +56,8 @@ jobs:
             const fs = require('fs');
             const branch = context.payload.pull_request?.head.ref ??
               context.ref.replace('refs/heads/', '');
-            if (!branch.startsWith('issue-')) {
+            const match = branch.match(/(?:^|\/)issue-(\d+)/);
+            if (!match) {
               core.setOutput('proceed', 'false');
               const msg = `Branch '${branch}' is not issue-specific. CI will be skipped.`;
               core.info(msg);
@@ -67,17 +70,6 @@ jobs:
                   'CI will be skipped.',
                   ''
                 ].join('\n')
-              );
-              return;
-            }
-            const match = branch.match(/^issue-(\d+)/);
-            if (!match) {
-              core.setOutput('proceed', 'false');
-              const msg = `Cannot parse issue number from branch '${branch}'`;
-              core.warning(msg);
-              fs.appendFileSync(
-                process.env.GITHUB_STEP_SUMMARY,
-                ['### Issue Status', '', msg, ''].join('\n')
               );
               return;
             }

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -53,8 +53,9 @@ Automating your Icon Editor builds and tests:
      - release branches: `release-alpha/*`, `release-beta/*`, `release-rc/*`
      - feature branches: `feature/*`
      - hotfix branches: `hotfix/*`
+     - issue branches: `issue-*`
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-   - An `issue-status` job gates execution: it skips all other jobs unless the source branch starts with `issue-<number>` and the linked GitHub issue’s Status is **In Progress**. For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
+   - An `issue-status` job gates execution: it skips all other jobs unless the source branch name contains `issue-<number>` (for example, `issue-123` or `feature/issue-123`) and the linked GitHub issue’s Status is **In Progress**. For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically. By default, the workflow populates the **“Company Name”** with `github.repository_owner` and the **“Author Name”** with `github.event.repository.name`, so each build is branded with your GitHub account and repository.
@@ -103,7 +104,7 @@ Below are the **key GitHub Actions** provided in this repository:
 
 The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks the build into several jobs:
 
-- **issue-status** – ensures CI runs only when the source branch is named `issue-<number>` and the linked GitHub issue has Status “In Progress”. For pull requests, the job evaluates the PR’s head branch.
+- **issue-status** – ensures CI runs only when the source branch name contains `issue-<number>` (such as `issue-123` or `feature/issue-123`) and the linked GitHub issue has Status “In Progress”. For pull requests, the job evaluates the PR’s head branch.
 - **changes** – checks out the repository and detects `.vipc` file changes to determine if dependencies need to be applied.
 - **apply-deps** – installs VIPC dependencies for multiple LabVIEW versions and bitnesses **only when** the `changes` job reports `.vipc` modifications (`if: needs.changes.outputs.vipc == 'true'`).
 - **version** – computes the semantic version and build number using commit count and PR labels.

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -94,7 +94,7 @@ It eliminates confusion around versioning, keeps everything in one pipeline, and
 
 ### 3.1 How the Action Is Triggered
 The `build-vi-package` directory defines a **composite action**. It does not listen for events on its own; instead, the CI workflow in [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) invokes it.
-That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. Pushes are limited to `main`, `develop`, `release-alpha/*`, `release-beta/*`, `release-rc/*`, `feature/*`, and `hotfix/*` branches, and pull requests must target one of those branches. However, `build-vi-package` executes only if the `issue-status` job allows the pipeline to continue: the source branch must start with `issue-<number>` and the linked issue's Status must be **In Progress**. For pull requests, the gate evaluates the PR’s head branch before proceeding, because its dependencies (`version` and `build-ppl`)
+That workflow runs on `push`, `pull_request`, and `workflow_dispatch` events. Pushes are limited to `main`, `develop`, `release-alpha/*`, `release-beta/*`, `release-rc/*`, `feature/*`, `hotfix/*`, and `issue-*` branches, and pull requests must target one of those branches. However, `build-vi-package` executes only if the `issue-status` job allows the pipeline to continue: the source branch name must contain `issue-<number>` (for example, `issue-123` or `feature/issue-123`) and the linked issue's Status must be **In Progress**. For pull requests, the gate evaluates the PR’s head branch before proceeding, because its dependencies (`version` and `build-ppl`)
 require that gate.
 
 ### 3.2 Configurable Inputs / Parameters


### PR DESCRIPTION
## Summary
- allow `issue-*` branches to trigger CI
- detect issue numbers in branches like `feature/issue-123`
- document how branch names interact with CI gate

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/labview-icon-editor/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894253c7c9c8329b290a6dd17e1a932