### PR TITLE
docs: clarify issue branch naming for CI gating

### DIFF
--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -225,7 +225,7 @@ All dev-mode logic resides in two PowerShell scripts:
  - **File Name**: `ci-composite.yml`
  - **Purpose**: A dedicated **version** job (using `compute-version`) derives the version from PR labels and commit count, and the **Build VI Package** job builds the `.vip` artifact using that version output.
 - **Features**:
-    - **Issue status gating**: skips most jobs unless the branch name starts with `issue-<number>` and the linked issue has Status **In Progress**.
+    - **Issue status gating**: skips most jobs unless the branch name contains `issue-<number>` (e.g., `issue-123`, `feature/issue-123`) and the linked issue has Status **In Progress**.
     - **Label-based** version bump (`major`, `minor`, `patch`), or none if unlabeled.
     - **Commit-based build number**: `vX.Y.Z-build<commitCount>` (plus optional pre-release suffix).
     - **Multi-Channel** detection for `release-alpha/*`, `release-beta/*`, `release-rc/*`.


### PR DESCRIPTION
## Summary
- document that CI gating runs for any branch containing `issue-<number>` to match the workflow regex

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689430a041d8832996f57ccd2f3770af