### PR TITLE
docs: clarify issue-status gate reference

### DIFF
--- a/docs/ci/actions/multichannel-release-workflow.md
+++ b/docs/ci/actions/multichannel-release-workflow.md
@@ -100,7 +100,7 @@ Use whichever patterns best fit your project’s branching model. If you prefer 
 <a name="issue-status-gate"></a>
 ### **Issue-Status Gate**
 
-The composite CI workflow only runs full jobs when the `issue-status` check succeeds. That job requires the source branch name to contain `issue-<number>` (for example, `release-alpha/issue-123` or `issue-456`) and the linked GitHub issue’s Status to be **In Progress**. Branches without this prefix—such as `release-alpha/2.0`—trigger the workflow but skip all subsequent jobs. See [ci-composite.yml](../../../.github/workflows/ci-composite.yml) for the `issue-status` job (currently lines 40‑119) and its downstream gate.
+The composite CI workflow only runs full jobs when the `issue-status` check succeeds. That job requires the source branch name to contain `issue-<number>` (for example, `release-alpha/issue-123` or `issue-456`) and the linked GitHub issue’s Status to be **In Progress**. Branches without this prefix—such as `release-alpha/2.0`—trigger the workflow but skip all subsequent jobs. See the `issue-status` job in [ci-composite.yml](../../../.github/workflows/ci-composite.yml) for details and its downstream gate.
 
 
 <a name="workflow-steps"></a>


### PR DESCRIPTION
## Summary
- clarify Issue-Status Gate section to reference `issue-status` job instead of line numbers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894359d12308329815739b128f38201