### PR TITLE
docs: note automatic cancellation of concurrent runs

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -57,6 +57,7 @@ Automating your Icon Editor builds and tests:
    - `workflow_dispatch` enables manual runs.
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
    - An `issue-status` job gates execution: it skips all other jobs unless the source branch name contains `issue-<number>` (for example, `issue-123` or `feature/issue-123`) and the linked GitHub issue’s Status is **In Progress**. For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
+   - A concurrency group cancels any previous run on the same branch, ensuring only the latest pipeline execution continues.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically. By default, the workflow populates the **“Company Name”** with `github.repository_owner` and the **“Author Name”** with `github.event.repository.name`, so each build is branded with your GitHub account and repository.


### PR DESCRIPTION
## Summary
- document that the CI workflow cancels prior runs for the same branch

## Testing
- `npx --yes markdownlint-cli docs/ci-workflows.md` *(fails: MD013 line length warnings, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6894b42938248329bb4a267ea727c068