### PR TITLE
docs: mention generated release notes

### DIFF
--- a/.github/actions/generate-release-notes/README.md
+++ b/.github/actions/generate-release-notes/README.md
@@ -1,7 +1,7 @@
 # Generate Release Notes
 
 This composite action creates a Markdown file summarizing commits since the last tag.
-The resulting file can be injected into the VI Package build process.
+By default, it writes to `Tooling/deployment/release_notes.md`, which you can use when drafting changelogs or GitHub releases.
 
 ## Inputs
 

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -63,6 +63,7 @@ Automating your Icon Editor builds and tests:
    - Produces `.vip` artifacts automatically. By default, the workflow populates the **“Company Name”** with `github.repository_owner` and the **“Author Name”** with `github.event.repository.name`, so each build is branded with your GitHub account and repository.
    - To use different branding, edit the **“Generate display information JSON”** step in [`.github/workflows/ci-composite.yml`](../.github/workflows/ci-composite.yml) and supply custom values for these fields.
    - Uses **label-based** version bumping (major/minor/patch) on pull requests.
+   - Generates `Tooling/deployment/release_notes.md` summarizing recent commits. Use this file to draft changelogs or release notes.
 
 6. **Disable Dev Mode** (optional)  
    Reverts your environment to normal LabVIEW settings, removing local overrides.

--- a/docs/ci/actions/README.md
+++ b/docs/ci/actions/README.md
@@ -11,7 +11,7 @@ This repository defines several reusable [composite actions](https://docs.github
 | [build-vi-package](../../../.github/actions/build-vi-package) | Updates a VIPB file and builds the VI package. |
 | [close-labview](../../../.github/actions/close-labview) | Gracefully shuts down a LabVIEW instance. |
 | [compute-version](../../../.github/actions/compute-version) | Determines the semantic version from commit history and labels. |
-| [generate-release-notes](../../../.github/actions/generate-release-notes) | Generates Markdown release notes from recent commits. |
+| [generate-release-notes](../../../.github/actions/generate-release-notes) | Generates a `release_notes.md` summarizing recent commits for use in changelogs or release drafts. |
 | [missing-in-project](../../../.github/actions/missing-in-project) | Checks a project for missing files using `MissingInProjectCLI.vi`. |
 | [modify-vipb-display-info](../../../.github/actions/modify-vipb-display-info) | Updates display information in a VIPB file. |
 | [prepare-labview-source](../../../.github/actions/prepare-labview-source) | Prepares LabVIEW sources for builds. |


### PR DESCRIPTION
## Summary
- document that CI workflow generates a `release_notes.md` file from recent commits
- describe generate-release-notes action output for changelog or release drafts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6894b814621c8329b2dec01158e0a2a1