### PR TITLE
docs: note rename-file action in build workflow

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -113,7 +113,7 @@ The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks 
 - **version** – computes the semantic version and build number using commit count and PR labels.
 - **missing-in-project-check** – verifies every source file is referenced in the `.lvproj`.
 - **test** – runs LabVIEW unit tests across the supported matrix.
-- **build-ppl** – uses a matrix to build 32-bit and 64-bit packed libraries.
+- **build-ppl** – uses a matrix to build 32-bit and 64-bit packed libraries, then uses the `rename-file` action to append the bitness to each library’s filename.
 - **build-vi-package** – packages the final VI Package using the built libraries and version information. In `ci-composite.yml` this job passes `supported_bitness: 64`, so it produces only a 64-bit `.vip`.
 
 The `build-ppl` job uses a matrix to produce both bitnesses rather than distinct jobs.


### PR DESCRIPTION
## Summary
- document that build-ppl renames built libraries using rename-file action to append bitness

## Testing
- `npx --yes markdownlint-cli docs/ci-workflows.md` *(fails: line length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6894b96b5324832995e97866798e671d