### PR TITLE
docs: mention automatic LabVIEW cleanup

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -116,6 +116,8 @@ The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks 
 - **build-ppl** – uses a matrix to build 32-bit and 64-bit packed libraries, then uses the `rename-file` action to append the bitness to each library’s filename.
 - **build-vi-package** – packages the final VI Package using the built libraries and version information. In `ci-composite.yml` this job passes `supported_bitness: 64`, so it produces only a 64-bit `.vip`.
 
+Both build jobs end with a `close-labview` step that shuts down LabVIEW to free up resources on the runner.
+
 The `build-ppl` job uses a matrix to produce both bitnesses rather than distinct jobs.
 
 *(The **Run Unit Tests** workflow has been consolidated into the main CI process.)*

--- a/docs/ci/actions/README.md
+++ b/docs/ci/actions/README.md
@@ -9,7 +9,7 @@ This repository defines several reusable [composite actions](https://docs.github
 | [build](../../../.github/actions/build) | **Deprecated**: previously orchestrated the full build and packaging process. |
 | [build-lvlibp](../../../.github/actions/build-lvlibp) | Creates the editor packed library. |
 | [build-vi-package](../../../.github/actions/build-vi-package) | Updates a VIPB file and builds the VI package. |
-| [close-labview](../../../.github/actions/close-labview) | Gracefully shuts down a LabVIEW instance. |
+| [close-labview](../../../.github/actions/close-labview) | Gracefully shuts down a LabVIEW instance after build steps to free runner resources. |
 | [compute-version](../../../.github/actions/compute-version) | Determines the semantic version from commit history and labels. |
 | [generate-release-notes](../../../.github/actions/generate-release-notes) | Generates a `release_notes.md` summarizing recent commits for use in changelogs or release drafts. |
 | [missing-in-project](../../../.github/actions/missing-in-project) | Checks a project for missing files using `MissingInProjectCLI.vi`. |


### PR DESCRIPTION
## Summary
- note in the CI workflow docs that build jobs invoke `close-labview` to release resources
- clarify `close-labview` action shuts down LabVIEW after build steps

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894bc55c4b08329aa43bfc753630aa9