### PR TITLE
docs: clarify CI composite job references

### DIFF
--- a/docs/ci/actions/injecting-repo-org-to-vi-package.md
+++ b/docs/ci/actions/injecting-repo-org-to-vi-package.md
@@ -44,7 +44,7 @@ We achieve this by:
 
 ## GitHub Actions and PowerShell
 
-A typical **GitHub Actions** workflow might have steps like. The composite CI workflow builds **32- and 64-bit** packed libraries separately, but the `build-vi-package` step packages only a **64-bit** VI package for **LabVIEW 2023**. The steps below mirror [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) lines 230-248 and 270-324:
+A typical **GitHub Actions** workflow might have steps like the snippet below. It is an illustrative example that condenses the process into a single job. In the actual [`ci-composite.yml`](../../../.github/workflows/ci-composite.yml) workflow, these steps are separated into the **`build-ppl`** and **`build-vi-package`** jobs. The snippet mirrors key steps such as `build-lvlibp`, `modify-vipb-display-info`, and `build-vi-package`:
 
 ```yaml
 jobs:


### PR DESCRIPTION
## Summary
- clarify that the workflow snippet is illustrative and point to the build-ppl and build-vi-package jobs in ci-composite
- reference step names like build-lvlibp, modify-vipb-display-info, and build-vi-package instead of line numbers

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894c93465688329a2451d7937f8fe48