### PR TITLE
docs: reference checkout v4 for full clone

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -173,7 +173,9 @@ jobs:
       BUILD:         ${{ steps.compute.outputs.BUILD }}
       IS_PRERELEASE: ${{ steps.compute.outputs.IS_PRERELEASE }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - id: compute
         uses: ./.github/actions/compute-version
         with:

--- a/docs/ci/actions/build-vi-package.md
+++ b/docs/ci/actions/build-vi-package.md
@@ -140,7 +140,7 @@ components remain unchanged and only the build number increases.
 ### 4.1 Pipeline Overview
 
 1. **Check Out & Full Clone**
-   - Uses `actions/checkout@v3` with `fetch-depth: 0` so we get the entire commit history (required for the commit-based build number).
+   - Uses `actions/checkout@v4` with `fetch-depth: 0` so we get the entire commit history (required for the commit-based build number).
 
 2. **Determine Bump Type**
    - On PR events, scans the PR labels: `major`, `minor`, `patch`, or defaults to `none`.  


### PR DESCRIPTION
## Summary
- document checkout step using `actions/checkout@v4`
- update CI workflow to use `actions/checkout@v4` with full history

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894dfb82cf88329875ab2db3c0efd2f