### PR TITLE
docs: clarify issue-status job gating

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -56,7 +56,7 @@ Automating your Icon Editor builds and tests:
      - issue branches: `issue-*`
    - `workflow_dispatch` enables manual runs.
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-   - An `issue-status` job gates execution: it skips all other jobs unless the source branch name contains `issue-<number>` (for example, `issue-123` or `feature/issue-123`) and the linked GitHub issue’s Status is **In Progress**. For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
+   - An `issue-status` job gates execution. It queries the **Status** field of the linked GitHub issue’s associated project and only proceeds when that field equals **In Progress**. Contributors must ensure their issue is added to a project with this Status value. The job also skips all other jobs unless the source branch name contains `issue-<number>` (for example, `issue-123` or `feature/issue-123`). For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
    - A concurrency group cancels any previous run on the same branch, ensuring only the latest pipeline execution continues.
 
 5. **Build VI Package**
@@ -107,7 +107,7 @@ Below are the **key GitHub Actions** provided in this repository:
 
 The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks the build into several jobs:
 
-- **issue-status** – ensures CI runs only when the source branch name contains `issue-<number>` (such as `issue-123` or `feature/issue-123`) and the linked GitHub issue has Status “In Progress”. For pull requests, the job evaluates the PR’s head branch.
+- **issue-status** – queries the **Status** field of the linked GitHub issue’s associated GitHub Project and proceeds only when that field is **In Progress**. Contributors must ensure their issue is added to a project with this Status value. It also requires the source branch name to contain `issue-<number>` (such as `issue-123` or `feature/issue-123`). For pull requests, the job evaluates the PR’s head branch.
 - **changes** – checks out the repository and detects `.vipc` file changes to determine if dependencies need to be applied.
 - **apply-deps** – installs VIPC dependencies for multiple LabVIEW versions and bitnesses **only when** the `changes` job reports `.vipc` modifications (`if: needs.changes.outputs.vipc == 'true'`).
 - **version** – computes the semantic version and build number using commit count and PR labels.


### PR DESCRIPTION
## Summary
- clarify that `issue-status` job checks the issue's project **Status** field and requires `In Progress`
- note that contributors must add their issue to a project with that status

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894e50659a48329a437ea98874db831