### PR TITLE
Clarify release instructions in automated setup

### DIFF
--- a/docs/automated-setup.md
+++ b/docs/automated-setup.md
@@ -184,12 +184,13 @@ Passing these metadata fields ensures the final `.vip` clearly identifies **whic
 3. **Open PR**
    - Label (`major`, `minor`, `patch`) for semver bump.
    - Actions use `Build.ps1` to produce `.vip` on merges.
-4. **Merge**  
-   - Creates a GitHub Release, attaches the `.vip`.  
-5. **Disable Dev Mode**  
-   - Revert environment.  
-6. **Install**  
-   - Use VIPM to install the `.vip` and confirm final functionality.  
+4. **Merge**
+   - The `.github/workflows/ci-composite.yml` workflow uploads the built `.vip` as an artifact in its ["Upload VI Package" step](../.github/workflows/ci-composite.yml#L330-L335).
+   - It does not automatically create a GitHub Release; draft one manually and attach the artifact if desired.
+5. **Disable Dev Mode**
+   - Revert environment.
+6. **Install**
+   - Use VIPM to install the `.vip` and confirm final functionality.
 
 All scripts are fully open-source—**collaborators** can debug or extend them locally with minimal friction. By passing organization/repo data in either local builds or GitHub Actions, you ensure your **unique** version of the Icon Editor is **clearly labeled** and **easily traced** to its source.
 


### PR DESCRIPTION
## Summary
- clarify that merging does not create a release automatically
- note that the ci-composite workflow only uploads the VI Package artifact

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e9d8cac883299e54158ff86b2d69