### PR TITLE
docs: update VIPC action sample versions

### DIFF
--- a/.github/actions/apply-vipc/README.md
+++ b/.github/actions/apply-vipc/README.md
@@ -43,12 +43,15 @@ steps:
   - name: Install LabVIEW dependencies
     uses: ./.github/actions/apply-vipc
     with:
-      minimum_supported_lv_version: 2024
-      vip_lv_version: 2024
+      minimum_supported_lv_version: 2021
+      vip_lv_version: 2021
       supported_bitness: 64
       relative_path: ${{ github.workspace }}
       vipc_path: Tooling/deployment/runner_dependencies.vipc
 ```
+
+The CI pipeline applies these dependencies across multiple LabVIEW versions—2021 (32-bit and 64-bit) and 2023 (64-bit)—as shown in
+[`.github/workflows/ci-composite.yml`](../../workflows/ci-composite.yml).
 
 ---
 


### PR DESCRIPTION
## Summary
- update apply-vipc action README to use LabVIEW 2021 in sample inputs
- note that CI installs dependencies for LabVIEW 2021 (32/64-bit) and 2023 (64-bit)

## Testing
- `npm test` *(fails: ENOENT no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6894eb5a7b908329810236b651bc9ce6