### PR TITLE
docs: align AuthorName metadata example

### DIFF
--- a/docs/automated-setup.md
+++ b/docs/automated-setup.md
@@ -123,7 +123,7 @@ An example step in a GitHub Actions file might look like:
       -Commit "${{ github.sha }}" `
       # You can pass metadata fields to brand the package:
       -CompanyName "${{ github.repository_owner }}" `
-      -AuthorName "${{ github.repository }}" `
+      -AuthorName "${{ github.event.repository.name }}" `
       -Verbose
 ```
 


### PR DESCRIPTION
## Summary
- update AuthorName example in automated setup docs to use `${{ github.event.repository.name }}`

## Testing
- `npm test` *(fails: could not find package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894ef3b36688329a652f51f2b0f2385