### PR TITLE
Respect NoCI label in CI workflow and docs

### DIFF
--- a/.github/workflows/ci-composite.yml
+++ b/.github/workflows/ci-composite.yml
@@ -74,6 +74,37 @@ jobs:
               return;
             }
             const issueNumber = parseInt(match[1], 10);
+
+            // Skip CI when a 'NoCI' label is present
+            const prNumber = context.payload.pull_request?.number;
+            let hasNoCILabel = false;
+            if (prNumber) {
+              hasNoCILabel = context.payload.pull_request.labels.some(l => l.name === 'NoCI');
+            } else {
+              const { data: prs } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branch}`,
+                state: 'open'
+              });
+              hasNoCILabel = prs.some(pr => pr.labels.some(l => l.name === 'NoCI'));
+            }
+            if (hasNoCILabel) {
+              core.setOutput('proceed', 'false');
+              const msg = `Branch '${branch}' is labeled 'NoCI'. CI will be skipped.`;
+              core.info(msg);
+              fs.appendFileSync(
+                process.env.GITHUB_STEP_SUMMARY,
+                [
+                  '### Issue Status',
+                  '',
+                  msg,
+                  ''
+                ].join('\n')
+              );
+              return;
+            }
+
             const query = `
               query($owner:String!, $repo:String!, $number:Int!){
                 repository(owner:$owner, name:$repo){

--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -56,7 +56,7 @@ Automating your Icon Editor builds and tests:
      - issue branches: `issue-*`
    - `workflow_dispatch` enables manual runs.
    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-   - An `issue-status` job gates execution. It queries the **Status** field of the linked GitHub issue’s associated project and only proceeds when that field equals **In Progress**. Contributors must ensure their issue is added to a project with this Status value. The job also skips all other jobs unless the source branch name contains `issue-<number>` (for example, `issue-123` or `feature/issue-123`). For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
+    - An `issue-status` job gates execution. It skips the workflow if a pull request or its branch carries a `NoCI` label, then queries the **Status** field of the linked GitHub issue’s associated project and only proceeds when that field equals **In Progress**. Contributors must ensure their issue is added to a project with this Status value. The job also skips all other jobs unless the source branch name contains `issue-<number>` (for example, `issue-123` or `feature/issue-123`). For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
    - A concurrency group cancels any previous run on the same branch, ensuring only the latest pipeline execution continues.
 
 5. **Build VI Package**
@@ -107,7 +107,7 @@ Below are the **key GitHub Actions** provided in this repository:
 
 The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks the build into several jobs:
 
-- **issue-status** – queries the **Status** field of the linked GitHub issue’s associated GitHub Project and proceeds only when that field is **In Progress**. Contributors must ensure their issue is added to a project with this Status value. It also requires the source branch name to contain `issue-<number>` (such as `issue-123` or `feature/issue-123`). For pull requests, the job evaluates the PR’s head branch.
+- **issue-status** – skips the workflow if the pull request or branch has a `NoCI` label, then queries the **Status** field of the linked GitHub issue’s associated GitHub Project and proceeds only when that field is **In Progress**. Contributors must ensure their issue is added to a project with this Status value. It also requires the source branch name to contain `issue-<number>` (such as `issue-123` or `feature/issue-123`). For pull requests, the job evaluates the PR’s head branch.
 - **changes** – checks out the repository and detects `.vipc` file changes to determine if dependencies need to be applied.
 - **apply-deps** – installs VIPC dependencies for multiple LabVIEW versions and bitnesses **only when** the `changes` job reports `.vipc` modifications (`if: needs.changes.outputs.vipc == 'true'`).
 - **version** – computes the semantic version and build number using commit count and PR labels.

--- a/docs/ci/actions/maintainers-guide.md
+++ b/docs/ci/actions/maintainers-guide.md
@@ -41,8 +41,9 @@ current.
   Coordinate with the NI Open-Source Program Manager (OSPM) before execution.
 - **Finalize experiment merges** – Prior to merging an experiment branch into
   `develop`, apply an appropriate version label (major/minor/patch) and remove
-  any temporary settings or `NoCI` labels. The OSPM or designated NI staff
-  typically gives the final approval.
+  any temporary settings or `NoCI` labels. A `NoCI` label causes the CI
+  workflow to skip all jobs, so clear it before running final tests. The OSPM
+  or designated NI staff typically gives the final approval.
 - **Hotfix branches** – For critical fixes on an official release, create or
   approve a `hotfix/*` branch targeting `main`. After merging into `main`, merge
   the changes back into `develop` to keep branches synchronized.

--- a/docs/ci/actions/troubleshooting-experiments.md
+++ b/docs/ci/actions/troubleshooting-experiments.md
@@ -50,11 +50,11 @@ Review the scan results in the GitHub Actions logs for your experiment branch. I
 **Symptom**  
 Your experiment branch still has a “NoCI” label after an admin ran the “approve-experiment” action, and CI jobs aren’t triggering automatically.
 
-**Cause**  
-The “approve-experiment” process might not automatically remove the “NoCI” label from the branch, or the label was added manually and not cleared.
+**Cause**
+The “approve-experiment” process might not automatically remove the “NoCI” label from the branch, or the label was added manually and not cleared. The `ci-composite` workflow skips all jobs when this label is present.
 
-**Solution (One Paragraph)**  
-First, verify in the Actions log that the approve step completed successfully. If CI is still skipped due to the “NoCI” label, remove that label from the experiment branch via the GitHub UI (you need maintainer permissions to edit labels). Going forward, ensure that the experiment branch has an “ApprovedCI” indicator (if used) or simply no “NoCI” label. This will allow normal CI workflows (like build/test) to run on pushes to that branch.
+**Solution (One Paragraph)**
+First, verify in the Actions log that the approve step completed successfully. If CI is still skipped due to the “NoCI” label, remove that label from the experiment branch via the GitHub UI (you need maintainer permissions to edit labels). Once the label is cleared, the `issue-status` job will permit subsequent jobs to run. Going forward, ensure that the experiment branch has an “ApprovedCI” indicator (if used) or simply no “NoCI” label. This will allow normal CI workflows (like build/test) to run on pushes to that branch.
 
 ---
 


### PR DESCRIPTION
## Summary
- skip CI jobs when a pull request or branch carries a `NoCI` label
- document how the `NoCI` label gates CI runs across guides and troubleshooting

## Testing
- `markdownlint docs/ci/actions/maintainers-guide.md docs/ci/actions/troubleshooting-experiments.md docs/ci-workflows.md` (fails: MD013 line-length and other warnings)
- `./actionlint .github/workflows/ci-composite.yml` (fails: unknown runner label)
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6894f3b411b48329a13f6c9a0b3876d3