### PR TITLE
docs: fix ci-composite link

### DIFF
--- a/docs/automated-setup.md
+++ b/docs/automated-setup.md
@@ -185,7 +185,7 @@ Passing these metadata fields ensures the final `.vip` clearly identifies **whic
    - Label (`major`, `minor`, `patch`) for semver bump.
    - Actions use `Build.ps1` to produce `.vip` on merges.
 4. **Merge**
-   - The `.github/workflows/ci-composite.yml` workflow uploads the built `.vip` as an artifact in its ["Upload VI Package" step](../.github/workflows/ci-composite.yml#L330-L335).
+   - The [`.github/workflows/ci-composite.yml`](../.github/workflows/ci-composite.yml) workflow uploads the built `.vip` as an artifact in its "Upload VI Package" step.
    - It does not automatically create a GitHub Release; draft one manually and attach the artifact if desired.
 5. **Disable Dev Mode**
    - Revert environment.


### PR DESCRIPTION
## Summary
- avoid line-number drift in automated setup by linking to ci-composite workflow's Upload VI Package step without anchors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689503da7b008329b6b37f4ac90d2858