### PR TITLE
docs: clarify patch default for unlabeled PRs

### DIFF
--- a/docs/powershell-cli-github-action-instructions.md
+++ b/docs/powershell-cli-github-action-instructions.md
@@ -226,7 +226,9 @@ All dev-mode logic resides in two PowerShell scripts:
  - **Purpose**: A dedicated **version** job (using `compute-version`) derives the version from PR labels and commit count, and the **Build VI Package** job builds the `.vip` artifact using that version output.
 - **Features**:
     - **Issue status gating**: skips most jobs unless the branch name contains `issue-<number>` (e.g., `issue-123`, `feature/issue-123`) and the linked issue has Status **In Progress**.
-    - **Label-based** version bump (`major`, `minor`, `patch`), or none if unlabeled.
+    - **Label-based** version bump (`major`, `minor`, `patch`); unlabeled pull requests
+      default to `patch` (see `.github/actions/compute-version/action.yml`, used by
+      `compute-version` in `ci-composite.yml`).
     - **Commit-based build number**: `vX.Y.Z-build<commitCount>` (plus optional pre-release suffix).
     - **Multi-Channel** detection for `release-alpha/*`, `release-beta/*`, `release-rc/*`.
     - **Upload Artifact**: Builds the `.vip` file and uploads it as a workflow artifact (no automatic GitHub Release attachment).


### PR DESCRIPTION
## Summary
- note unlabeled pull requests default to a patch version bump in the CI workflow
- reference compute-version action to highlight the patch default

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689508d4df9083299c2f7b0f136be852