### PR TITLE
docs: clarify issue branch requirements for CI

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -54,11 +54,11 @@ Automating your Icon Editor builds and tests:
      - feature branches: `feature/*`
      - hotfix branches: `hotfix/*`
      - issue branches: `issue-*`
-    - `workflow_dispatch` enables manual runs.
-    - Manual runs still require the branch name to match `issue-<number>` and the linked issue's Status to be **In Progress**; otherwise, downstream jobs are skipped.
-    - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
-    - An `issue-status` job gates execution. It skips the workflow if a pull request or its branch carries a `NoCI` label, then queries the **Status** field of the linked GitHub issue’s associated project and only proceeds when that field equals **In Progress**. Contributors must ensure their issue is added to a project with this Status value. The job also skips all other jobs unless the source branch name contains `issue-<number>` (for example, `issue-123` or `feature/issue-123`). For pull requests, the check inspects the PR’s head branch. This gating helps avoid ambiguous runs for automated tools.
-   - A concurrency group cancels any previous run on the same branch, ensuring only the latest pipeline execution continues.
+     - `workflow_dispatch` enables manual runs.
+     - Every run—push, pull request, or manual—requires the source branch name to match `issue-<number>` and the linked issue's Status to be **In Progress**; otherwise, downstream jobs are skipped.
+     - Typically run with Dev Mode **disabled** unless you’re testing dev features specifically.
+     - The `issue-status` job enforces these checks and also skips the workflow if the branch or pull request has a `NoCI` label. Contributors must ensure their issue is added to a project with the required Status. For pull requests, the check inspects the head branch. This gating helps avoid ambiguous runs for automated tools.
+     - A concurrency group cancels any previous run on the same branch, ensuring only the latest pipeline execution continues.
 
 5. **Build VI Package**
    - Produces `.vip` artifacts automatically. By default, the workflow populates the **“Company Name”** with `github.repository_owner` and the **“Author Name”** with `github.event.repository.name`, so each build is branded with your GitHub account and repository.


### PR DESCRIPTION
## Summary
- note that any `ci-composite.yml` run requires an `issue-<number>` branch and linked issue with Status **In Progress**
- mention that `issue-status` skips jobs when the branch or PR is labeled `NoCI`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689547079454832990e1ed847b97e723