### PR TITLE
docs: add LabVIEW 2023 dependency steps

### DIFF
--- a/docs/automated-setup.md
+++ b/docs/automated-setup.md
@@ -26,7 +26,7 @@ This document describes how to **build, test, and distribute** the **LabVIEW Ico
 - **Prerequisites**:
   1. **LabVIEW 2021 SP1 (both 32-bit and 64-bit)** and **LabVIEW 2023 (64-bit) for package building**.
   2. **PowerShell 7+** and **Git**.  
-  3. **Apply** `.github\actions\apply-vipc\runner_dependencies.vipc` **(to both 32-bit and 64-bit)**.
+  3. **Apply** `.github\actions\apply-vipc\runner_dependencies.vipc` to **LabVIEW 2021 (32-bit & 64-bit)** and **LabVIEW 2023 (64-bit)**—matching the `apply-deps` matrix in [`../.github/workflows/ci-composite.yml`](../.github/workflows/ci-composite.yml).
 
 ---
 
@@ -40,7 +40,7 @@ This document describes how to **build, test, and distribute** the **LabVIEW Ico
 2. **Clone** the [Icon Editor](https://github.com/ni/labview-icon-editor.git) to your development location.
 
 3. **Apply** dependencies:  
-   `.github\actions\apply-vipc\runner_dependencies.vipc` to **LabVIEW 2021 (32-bit) and LabVIEW 2021 (64-bit)**.
+   `.github\actions\apply-vipc\runner_dependencies.vipc` to **LabVIEW 2021 (32-bit & 64-bit)** and **LabVIEW 2023 (64-bit)**.
 
 4. **Open** PowerShell (Admin):
    Navigate to `.github\actions\set-development-mode`
@@ -62,8 +62,8 @@ This document describes how to **build, test, and distribute** the **LabVIEW Ico
 ## 3. Distribution Guide (VI Package via PowerShell)
 
 1. **Apply Dependencies** in VIPM:
-   - Set LabVIEW to 2021 (32-bit), apply `.github\actions\apply-vipc\runner_dependencies.vipc`.
-   - Repeat for 64-bit if necessary.
+   - Set LabVIEW to 2021 (32-bit) and apply `.github\actions\apply-vipc\runner_dependencies.vipc`.
+   - Repeat for **2021 (64-bit)** and **2023 (64-bit)** so all versions from the `apply-deps` matrix are covered.
 
 2. **Disable LabVIEW Security Warnings** *(to prevent popups from "run when opened" VIs)*:
    - **Tools → Options → Security** → **Run VI Without Warnings**.


### PR DESCRIPTION
## Summary
- document applying `runner_dependencies.vipc` to LabVIEW 2021 32/64-bit and LabVIEW 2023 64-bit
- note that this matches the `apply-deps` matrix in the composite CI workflow

## Testing
- `pwsh .github/actions/run-unit-tests/RunUnitTests.ps1 -MinimumSupportedLVVersion 2021 -SupportedBitness 64` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68954a3f97ac8329afb822c5ed869c12