### PR TITLE
Clarify close-labview step placement in build jobs

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -117,7 +117,7 @@ The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks 
 - **build-ppl** – uses a matrix to build 32-bit and 64-bit packed libraries, then uses the `rename-file` action to append the bitness to each library’s filename.
 - **build-vi-package** – packages the final VI Package using the built libraries and version information. In `ci-composite.yml` this job passes `supported_bitness: 64`, so it produces only a 64-bit `.vip`.
 
-Both build jobs end with a `close-labview` step that shuts down LabVIEW to free up resources on the runner.
+Both `build-ppl` and `build-vi-package` include a `close-labview` step that runs immediately after the build actions. This closes LabVIEW before later steps—such as renaming files or uploading artifacts—run, rather than serving as the final job step.
 
 The `build-ppl` job uses a matrix to produce both bitnesses rather than distinct jobs.
 


### PR DESCRIPTION
## Summary
- clarify when the `close-labview` step runs in `build-ppl` and `build-vi-package`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68954c9bbce08329b997f415e61f4406