### PR TITLE
docs: update minimum LabVIEW version

### DIFF
--- a/.github/actions/build-lvlibp/README.md
+++ b/.github/actions/build-lvlibp/README.md
@@ -15,10 +15,13 @@ Call **`Build_lvlibp.ps1`** to compile the editor packed library using g-cli.
 | `commit` | **Yes** | `abcdef` | Commit identifier. |
 
 ## Quick-start
+
+The following example builds using LabVIEW 2021.
+
 ```yaml
 - uses: ./.github/actions/build-lvlibp
   with:
-    minimum_supported_lv_version: 2024
+    minimum_supported_lv_version: 2021
     supported_bitness: 64
     relative_path: ${{ github.workspace }}
     major: 1


### PR DESCRIPTION
## Summary
- note that build-lvlibp quick-start example uses LabVIEW 2021

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895506bc374832999f89eac37def231