### PR TITLE
Clarify timing of close-labview step in build workflows

### DIFF
--- a/docs/ci-workflows.md
+++ b/docs/ci-workflows.md
@@ -117,7 +117,7 @@ The [`ci-composite.yml`](../.github/workflows/ci-composite.yml) pipeline breaks 
 - **build-ppl** – uses a matrix to build 32-bit and 64-bit packed libraries, then uses the `rename-file` action to append the bitness to each library’s filename.
 - **build-vi-package** – packages the final VI Package using the built libraries and version information. In `ci-composite.yml` this job passes `supported_bitness: 64`, so it produces only a 64-bit `.vip`.
 
-Both `build-ppl` and `build-vi-package` include a `close-labview` step that runs immediately after the build actions. This closes LabVIEW before later steps—such as renaming files or uploading artifacts—run, rather than serving as the final job step.
+Both `build-ppl` and `build-vi-package` run a `close-labview` step after their build actions finish but before any steps that rename files or upload artifacts, so it isn't the job's final step.
 
 The `build-ppl` job uses a matrix to produce both bitnesses rather than distinct jobs.
 


### PR DESCRIPTION
## Summary
- Document that `close-labview` runs after build actions and before renaming/upload steps in `build-ppl` and `build-vi-package` jobs.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895570bf5dc8329b6ebe111f5b3779e