### PR TITLE
docs: reference workflow jobs by name

### DIFF
--- a/docs/ci/troubleshooting-faq.md
+++ b/docs/ci/troubleshooting-faq.md
@@ -146,18 +146,18 @@ Below are 13 possible issues you might encounter, along with suggested steps to 
 
 **Possible Causes**:
 - Strict branch protection rules require approvals or passing checks before merging.
-- The [`issue-status`](../../.github/workflows/ci-composite.yml#L41-L151) job determined the branch name or issue status was invalid, so downstream checks were skipped.
+- The [`issue-status`](../../.github/workflows/ci-composite.yml#issue-status) job determined the branch name or issue status was invalid, so downstream checks were skipped.
 - You’re lacking the required PR reviews or status checks.
 
 **Solution**:
 1. Have the required reviewers approve your Pull Request.
 2. Ensure all required status checks pass:
-   - [`issue-status`](../../.github/workflows/ci-composite.yml#L41-L151) – verifies branch naming and issue status. If it fails or is skipped, downstream jobs won’t run.
-   - [`changes`](../../.github/workflows/ci-composite.yml#L153-L170) – detects `.vipc` file changes.
-   - [`apply-deps`](../../.github/workflows/ci-composite.yml#L171-L193) – applies VIPC dependencies when needed.
-   - [`missing-in-project-check`](../../.github/workflows/ci-composite.yml#L215-L230) – validates project file membership.
-   - [`Run Unit Tests`](../../.github/workflows/ci-composite.yml#L232-L247) – executes unit tests.
-   - [`Build VI Package`](../../.github/workflows/ci-composite.yml#L287-L340) – produces the `.vip` artifact.
+   - [`issue-status`](../../.github/workflows/ci-composite.yml#issue-status) – verifies branch naming and issue status. If it fails or is skipped, downstream jobs won’t run.
+   - [`changes`](../../.github/workflows/ci-composite.yml#changes) – detects `.vipc` file changes.
+   - [`apply-deps`](../../.github/workflows/ci-composite.yml#apply-deps) – applies VIPC dependencies when needed.
+   - [`missing-in-project-check`](../../.github/workflows/ci-composite.yml#missing-in-project-check) – validates project file membership.
+   - [`Run Unit Tests`](../../.github/workflows/ci-composite.yml#test) – executes unit tests.
+   - [`Build VI Package`](../../.github/workflows/ci-composite.yml#build-vi-package) – produces the `.vip` artifact.
 3. Update your `CONTRIBUTING.md` to specify the merging rules so contributors know what’s needed.
 
 ---


### PR DESCRIPTION
## Summary
- link troubleshooting FAQ to workflow jobs using job anchors instead of line numbers

## Testing
- `npx --yes markdownlint-cli docs/ci/troubleshooting-faq.md` *(fails: MD013/line-length, MD012/no-multiple-blanks, MD032/blanks-around-lists, MD047/single-trailing-newline)*

------
https://chatgpt.com/codex/tasks/task_e_68955ce273c0832988357c09eff50bc0